### PR TITLE
feat: Paperless-NGX client layer — read and write sub-clients (Phases E–F)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ ignore = ["E501"]
 # httpx appears in except clauses (runtime); AsyncIterator used in generator return types.
 "src/paperless_mcp/client/_errors.py" = ["TC002"]
 "src/paperless_mcp/client/_http.py" = ["TC003"]
+# PaperlessHTTP is stored as self._http at runtime; TracebackType used in __aexit__.
+"src/paperless_mcp/client/*.py" = ["TC001", "TC002", "TC003"]
 # Add project-specific overrides below as needed.
 
 [tool.ruff.lint.isort]

--- a/src/paperless_mcp/client/__init__.py
+++ b/src/paperless_mcp/client/__init__.py
@@ -1,7 +1,18 @@
 """Paperless-NGX REST client."""
+
 from __future__ import annotations
+
 from types import TracebackType
-from paperless_mcp.client._errors import AuthError, ConflictError, NotFoundError, PaperlessAPIError, RateLimitError, UpstreamError, ValidationError
+
+from paperless_mcp.client._errors import (
+    AuthError,
+    ConflictError,
+    NotFoundError,
+    PaperlessAPIError,
+    RateLimitError,
+    UpstreamError,
+    ValidationError,
+)
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.correspondents import CorrespondentsClient
 from paperless_mcp.client.custom_fields import CustomFieldsClient
@@ -14,11 +25,24 @@ from paperless_mcp.client.system import SystemClient
 from paperless_mcp.client.tags import TagsClient
 from paperless_mcp.client.tasks import TasksClient
 
+
 class PaperlessClient:
     """High-level async client aggregating every resource client."""
 
-    def __init__(self, *, base_url: str, api_token: str, timeout_seconds: float = 30.0, max_retries: int = 2) -> None:
-        self._http = PaperlessHTTP(base_url=base_url, api_token=api_token, timeout_seconds=timeout_seconds, max_retries=max_retries)
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_token: str,
+        timeout_seconds: float = 30.0,
+        max_retries: int = 2,
+    ) -> None:
+        self._http = PaperlessHTTP(
+            base_url=base_url,
+            api_token=api_token,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+        )
         self.documents = DocumentsClient(self._http)
         self.tags = TagsClient(self._http)
         self.correspondents = CorrespondentsClient(self._http)
@@ -37,13 +61,25 @@ class PaperlessClient:
     async def aclose(self) -> None:
         await self._http.aclose()
 
-    async def __aenter__(self) -> "PaperlessClient":
+    async def __aenter__(self) -> PaperlessClient:
         return self
 
-    async def __aexit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         await self.aclose()
 
+
 __all__ = [
-    "AuthError", "ConflictError", "NotFoundError", "PaperlessAPIError",
-    "PaperlessClient", "RateLimitError", "UpstreamError", "ValidationError",
+    "AuthError",
+    "ConflictError",
+    "NotFoundError",
+    "PaperlessAPIError",
+    "PaperlessClient",
+    "RateLimitError",
+    "UpstreamError",
+    "ValidationError",
 ]

--- a/src/paperless_mcp/client/__init__.py
+++ b/src/paperless_mcp/client/__init__.py
@@ -1,28 +1,49 @@
-"""Paperless-NGX REST client.
-
-Public API:
-    PaperlessClient — facade aggregating resource clients.
-    PaperlessAPIError and subclasses — typed exceptions.
-"""
-
+"""Paperless-NGX REST client."""
 from __future__ import annotations
+from types import TracebackType
+from paperless_mcp.client._errors import AuthError, ConflictError, NotFoundError, PaperlessAPIError, RateLimitError, UpstreamError, ValidationError
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.correspondents import CorrespondentsClient
+from paperless_mcp.client.custom_fields import CustomFieldsClient
+from paperless_mcp.client.document_types import DocumentTypesClient
+from paperless_mcp.client.documents import DocumentsClient
+from paperless_mcp.client.saved_views import SavedViewsClient
+from paperless_mcp.client.share_links import ShareLinksClient
+from paperless_mcp.client.storage_paths import StoragePathsClient
+from paperless_mcp.client.system import SystemClient
+from paperless_mcp.client.tags import TagsClient
+from paperless_mcp.client.tasks import TasksClient
 
-from paperless_mcp.client._errors import (
-    AuthError,
-    ConflictError,
-    NotFoundError,
-    PaperlessAPIError,
-    RateLimitError,
-    UpstreamError,
-    ValidationError,
-)
+class PaperlessClient:
+    """High-level async client aggregating every resource client."""
+
+    def __init__(self, *, base_url: str, api_token: str, timeout_seconds: float = 30.0, max_retries: int = 2) -> None:
+        self._http = PaperlessHTTP(base_url=base_url, api_token=api_token, timeout_seconds=timeout_seconds, max_retries=max_retries)
+        self.documents = DocumentsClient(self._http)
+        self.tags = TagsClient(self._http)
+        self.correspondents = CorrespondentsClient(self._http)
+        self.document_types = DocumentTypesClient(self._http)
+        self.custom_fields = CustomFieldsClient(self._http)
+        self.storage_paths = StoragePathsClient(self._http)
+        self.saved_views = SavedViewsClient(self._http)
+        self.share_links = ShareLinksClient(self._http)
+        self.tasks = TasksClient(self._http)
+        self.system = SystemClient(self._http)
+
+    @property
+    def http(self) -> PaperlessHTTP:
+        return self._http
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    async def __aenter__(self) -> "PaperlessClient":
+        return self
+
+    async def __aexit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None:
+        await self.aclose()
 
 __all__ = [
-    "AuthError",
-    "ConflictError",
-    "NotFoundError",
-    "PaperlessAPIError",
-    "RateLimitError",
-    "UpstreamError",
-    "ValidationError",
+    "AuthError", "ConflictError", "NotFoundError", "PaperlessAPIError",
+    "PaperlessClient", "RateLimitError", "UpstreamError", "ValidationError",
 ]

--- a/src/paperless_mcp/client/_http.py
+++ b/src/paperless_mcp/client/_http.py
@@ -100,8 +100,21 @@ class PaperlessHTTP:
     async def patch_json(self, path: str, *, json: Any | None = None) -> Any:
         return await self._request_json("PATCH", path, json=json)
 
-    async def delete(self, path: str) -> None:
-        await self._request("DELETE", path)
+    async def delete(self, path: str, *, params: dict[str, Any] | None = None) -> None:
+        await self._request("DELETE", path, params=params)
+
+    async def upload_multipart(
+        self,
+        path: str,
+        *,
+        data: dict[str, Any],
+        files: dict[str, Any],
+    ) -> Any:
+        """POST a multipart/form-data request (e.g. document upload)."""
+        response = await self._request("POST", path, data=data, files=files)
+        if response.status_code == 204 or not response.content:
+            return None
+        return response.json()
 
     async def stream_bytes(
         self, path: str, *, params: dict[str, Any] | None = None
@@ -170,13 +183,15 @@ class PaperlessHTTP:
         path: str,
         *,
         json: Any | None = None,
+        data: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> httpx.Response:
         attempt = 0
         while True:
             try:
                 response = await self._client.request(
-                    method, path, json=json, params=params
+                    method, path, json=json, data=data, files=files, params=params
                 )
             except httpx.RequestError as exc:
                 if method in _IDEMPOTENT_METHODS and attempt < self._max_retries:

--- a/src/paperless_mcp/client/correspondents.py
+++ b/src/paperless_mcp/client/correspondents.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.correspondent import Correspondent
+
+class CorrespondentsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[Correspondent]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        if name__icontains: params["name__icontains"] = name__icontains
+        body = await self._http.get_json("/api/correspondents/", params=params)
+        return Paginated[Correspondent].model_validate(body)
+
+    async def get(self, correspondent_id: int) -> Correspondent:
+        body = await self._http.get_json(f"/api/correspondents/{correspondent_id}/")
+        return Correspondent.model_validate(body)

--- a/src/paperless_mcp/client/correspondents.py
+++ b/src/paperless_mcp/client/correspondents.py
@@ -1,19 +1,124 @@
+"""Correspondents resource client."""
+
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import Paginated
-from paperless_mcp.models.correspondent import Correspondent
+from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.correspondent import (
+    Correspondent,
+    CorrespondentCreate,
+    CorrespondentPatch,
+)
+
 
 class CorrespondentsClient:
+    """Async operations against ``/api/correspondents/``."""
+
+    _OBJECT_TYPE = "correspondents"
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[Correspondent]:
+    async def list(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        ordering: str | None = None,
+        name__icontains: str | None = None,
+    ) -> Paginated[Correspondent]:
+        """List correspondents with optional filtering.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field to order by.
+            name__icontains: Filter correspondents whose name contains this string.
+
+        Returns:
+            A paginated list of :class:`Correspondent` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
-        if name__icontains: params["name__icontains"] = name__icontains
+        if ordering:
+            params["ordering"] = ordering
+        if name__icontains:
+            params["name__icontains"] = name__icontains
         body = await self._http.get_json("/api/correspondents/", params=params)
         return Paginated[Correspondent].model_validate(body)
 
     async def get(self, correspondent_id: int) -> Correspondent:
+        """Fetch a single correspondent by ID.
+
+        Args:
+            correspondent_id: ID of the correspondent to fetch.
+
+        Returns:
+            The :class:`Correspondent` with the given ID.
+        """
         body = await self._http.get_json(f"/api/correspondents/{correspondent_id}/")
         return Correspondent.model_validate(body)
+
+    async def create(self, body: CorrespondentCreate) -> Correspondent:
+        """Create a new correspondent.
+
+        Args:
+            body: Correspondent creation payload.
+
+        Returns:
+            The newly created :class:`Correspondent`.
+        """
+        payload = body.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.post_json("/api/correspondents/", json=payload)
+        return Correspondent.model_validate(response)
+
+    async def update(
+        self, correspondent_id: int, patch: CorrespondentPatch
+    ) -> Correspondent:
+        """Partially update a correspondent via PATCH.
+
+        Args:
+            correspondent_id: ID of the correspondent to update.
+            patch: Fields to update; unset fields are excluded from the payload.
+
+        Returns:
+            The updated :class:`Correspondent`.
+        """
+        payload = patch.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.patch_json(
+            f"/api/correspondents/{correspondent_id}/", json=payload
+        )
+        return Correspondent.model_validate(response)
+
+    async def delete(self, correspondent_id: int) -> None:
+        """Delete a correspondent by ID.
+
+        Args:
+            correspondent_id: ID of the correspondent to delete.
+        """
+        await self._http.delete(f"/api/correspondents/{correspondent_id}/")
+
+    async def bulk_edit(
+        self,
+        *,
+        operation: str,
+        ids: list[int],
+        parameters: dict[str, object] | None = None,
+    ) -> BulkEditResult:
+        """Perform a bulk edit operation on multiple correspondents.
+
+        Args:
+            operation: The operation to perform (e.g. ``"set_permissions"``).
+            ids: List of correspondent IDs to act on.
+            parameters: Optional extra parameters for the operation.
+
+        Returns:
+            A :class:`BulkEditResult` with the operation result.
+        """
+        payload: dict[str, object] = {
+            "object_type": self._OBJECT_TYPE,
+            "objects": ids,
+            "operation": operation,
+            "parameters": parameters or {},
+        }
+        body = await self._http.post_json("/api/bulk_edit_objects/", json=payload)
+        return BulkEditResult.model_validate(body)

--- a/src/paperless_mcp/client/correspondents.py
+++ b/src/paperless_mcp/client/correspondents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import BulkEditResult, Paginated
 from paperless_mcp.models.correspondent import (
@@ -101,7 +103,7 @@ class CorrespondentsClient:
         self,
         *,
         operation: str,
-        ids: list[int],
+        ids: Sequence[int],
         parameters: dict[str, object] | None = None,
     ) -> BulkEditResult:
         """Perform a bulk edit operation on multiple correspondents.

--- a/src/paperless_mcp/client/custom_fields.py
+++ b/src/paperless_mcp/client/custom_fields.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import BulkEditResult, Paginated
 from paperless_mcp.models.custom_field import (
@@ -95,7 +97,7 @@ class CustomFieldsClient:
         self,
         *,
         operation: str,
-        ids: list[int],
+        ids: Sequence[int],
         parameters: dict[str, object] | None = None,
     ) -> BulkEditResult:
         """Perform a bulk edit operation on multiple custom fields.

--- a/src/paperless_mcp/client/custom_fields.py
+++ b/src/paperless_mcp/client/custom_fields.py
@@ -1,18 +1,118 @@
+"""Custom fields resource client."""
+
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import Paginated
-from paperless_mcp.models.custom_field import CustomField
+from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.custom_field import (
+    CustomField,
+    CustomFieldCreate,
+    CustomFieldPatch,
+)
+
 
 class CustomFieldsClient:
+    """Async operations against ``/api/custom_fields/``."""
+
+    _OBJECT_TYPE = "custom_fields"
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None) -> Paginated[CustomField]:
+    async def list(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        ordering: str | None = None,
+    ) -> Paginated[CustomField]:
+        """List custom fields with optional ordering.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field to order by.
+
+        Returns:
+            A paginated list of :class:`CustomField` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
+        if ordering:
+            params["ordering"] = ordering
         body = await self._http.get_json("/api/custom_fields/", params=params)
         return Paginated[CustomField].model_validate(body)
 
     async def get(self, field_id: int) -> CustomField:
+        """Fetch a single custom field by ID.
+
+        Args:
+            field_id: ID of the custom field to fetch.
+
+        Returns:
+            The :class:`CustomField` with the given ID.
+        """
         body = await self._http.get_json(f"/api/custom_fields/{field_id}/")
         return CustomField.model_validate(body)
+
+    async def create(self, body: CustomFieldCreate) -> CustomField:
+        """Create a new custom field.
+
+        Args:
+            body: Custom field creation payload.
+
+        Returns:
+            The newly created :class:`CustomField`.
+        """
+        payload = body.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.post_json("/api/custom_fields/", json=payload)
+        return CustomField.model_validate(response)
+
+    async def update(self, field_id: int, patch: CustomFieldPatch) -> CustomField:
+        """Partially update a custom field via PATCH.
+
+        Args:
+            field_id: ID of the custom field to update.
+            patch: Fields to update; unset fields are excluded from the payload.
+
+        Returns:
+            The updated :class:`CustomField`.
+        """
+        payload = patch.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.patch_json(
+            f"/api/custom_fields/{field_id}/", json=payload
+        )
+        return CustomField.model_validate(response)
+
+    async def delete(self, field_id: int) -> None:
+        """Delete a custom field by ID.
+
+        Args:
+            field_id: ID of the custom field to delete.
+        """
+        await self._http.delete(f"/api/custom_fields/{field_id}/")
+
+    async def bulk_edit(
+        self,
+        *,
+        operation: str,
+        ids: list[int],
+        parameters: dict[str, object] | None = None,
+    ) -> BulkEditResult:
+        """Perform a bulk edit operation on multiple custom fields.
+
+        Args:
+            operation: The operation to perform (e.g. ``"set_permissions"``).
+            ids: List of custom field IDs to act on.
+            parameters: Optional extra parameters for the operation.
+
+        Returns:
+            A :class:`BulkEditResult` with the operation result.
+        """
+        payload: dict[str, object] = {
+            "object_type": self._OBJECT_TYPE,
+            "objects": ids,
+            "operation": operation,
+            "parameters": parameters or {},
+        }
+        body = await self._http.post_json("/api/bulk_edit_objects/", json=payload)
+        return BulkEditResult.model_validate(body)

--- a/src/paperless_mcp/client/custom_fields.py
+++ b/src/paperless_mcp/client/custom_fields.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.custom_field import CustomField
+
+class CustomFieldsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None) -> Paginated[CustomField]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        body = await self._http.get_json("/api/custom_fields/", params=params)
+        return Paginated[CustomField].model_validate(body)
+
+    async def get(self, field_id: int) -> CustomField:
+        body = await self._http.get_json(f"/api/custom_fields/{field_id}/")
+        return CustomField.model_validate(body)

--- a/src/paperless_mcp/client/document_types.py
+++ b/src/paperless_mcp/client/document_types.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import BulkEditResult, Paginated
 from paperless_mcp.models.document_type import (
@@ -101,7 +103,7 @@ class DocumentTypesClient:
         self,
         *,
         operation: str,
-        ids: list[int],
+        ids: Sequence[int],
         parameters: dict[str, object] | None = None,
     ) -> BulkEditResult:
         """Perform a bulk edit operation on multiple document types.

--- a/src/paperless_mcp/client/document_types.py
+++ b/src/paperless_mcp/client/document_types.py
@@ -1,19 +1,124 @@
+"""Document types resource client."""
+
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import Paginated
-from paperless_mcp.models.document_type import DocumentType
+from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.document_type import (
+    DocumentType,
+    DocumentTypeCreate,
+    DocumentTypePatch,
+)
+
 
 class DocumentTypesClient:
+    """Async operations against ``/api/document_types/``."""
+
+    _OBJECT_TYPE = "document_types"
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[DocumentType]:
+    async def list(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        ordering: str | None = None,
+        name__icontains: str | None = None,
+    ) -> Paginated[DocumentType]:
+        """List document types with optional filtering.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field to order by.
+            name__icontains: Filter document types whose name contains this string.
+
+        Returns:
+            A paginated list of :class:`DocumentType` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
-        if name__icontains: params["name__icontains"] = name__icontains
+        if ordering:
+            params["ordering"] = ordering
+        if name__icontains:
+            params["name__icontains"] = name__icontains
         body = await self._http.get_json("/api/document_types/", params=params)
         return Paginated[DocumentType].model_validate(body)
 
     async def get(self, document_type_id: int) -> DocumentType:
+        """Fetch a single document type by ID.
+
+        Args:
+            document_type_id: ID of the document type to fetch.
+
+        Returns:
+            The :class:`DocumentType` with the given ID.
+        """
         body = await self._http.get_json(f"/api/document_types/{document_type_id}/")
         return DocumentType.model_validate(body)
+
+    async def create(self, body: DocumentTypeCreate) -> DocumentType:
+        """Create a new document type.
+
+        Args:
+            body: Document type creation payload.
+
+        Returns:
+            The newly created :class:`DocumentType`.
+        """
+        payload = body.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.post_json("/api/document_types/", json=payload)
+        return DocumentType.model_validate(response)
+
+    async def update(
+        self, document_type_id: int, patch: DocumentTypePatch
+    ) -> DocumentType:
+        """Partially update a document type via PATCH.
+
+        Args:
+            document_type_id: ID of the document type to update.
+            patch: Fields to update; unset fields are excluded from the payload.
+
+        Returns:
+            The updated :class:`DocumentType`.
+        """
+        payload = patch.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.patch_json(
+            f"/api/document_types/{document_type_id}/", json=payload
+        )
+        return DocumentType.model_validate(response)
+
+    async def delete(self, document_type_id: int) -> None:
+        """Delete a document type by ID.
+
+        Args:
+            document_type_id: ID of the document type to delete.
+        """
+        await self._http.delete(f"/api/document_types/{document_type_id}/")
+
+    async def bulk_edit(
+        self,
+        *,
+        operation: str,
+        ids: list[int],
+        parameters: dict[str, object] | None = None,
+    ) -> BulkEditResult:
+        """Perform a bulk edit operation on multiple document types.
+
+        Args:
+            operation: The operation to perform (e.g. ``"set_permissions"``).
+            ids: List of document type IDs to act on.
+            parameters: Optional extra parameters for the operation.
+
+        Returns:
+            A :class:`BulkEditResult` with the operation result.
+        """
+        payload: dict[str, object] = {
+            "object_type": self._OBJECT_TYPE,
+            "objects": ids,
+            "operation": operation,
+            "parameters": parameters or {},
+        }
+        body = await self._http.post_json("/api/bulk_edit_objects/", json=payload)
+        return BulkEditResult.model_validate(body)

--- a/src/paperless_mcp/client/document_types.py
+++ b/src/paperless_mcp/client/document_types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.document_type import DocumentType
+
+class DocumentTypesClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[DocumentType]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        if name__icontains: params["name__icontains"] = name__icontains
+        body = await self._http.get_json("/api/document_types/", params=params)
+        return Paginated[DocumentType].model_validate(body)
+
+    async def get(self, document_type_id: int) -> DocumentType:
+        body = await self._http.get_json(f"/api/document_types/{document_type_id}/")
+        return DocumentType.model_validate(body)

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -40,6 +40,21 @@ class DocumentsClient:
         storage_path: int | None = None,
         custom_field: int | None = None,
     ) -> Paginated[Document]:
+        """List documents with optional server-side filtering.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field name to order by (prefix with ``-`` for descending).
+            tags: Filter to documents containing all of these tag IDs.
+            correspondent: Filter by correspondent ID.
+            document_type: Filter by document type ID.
+            storage_path: Filter by storage path ID.
+            custom_field: Filter by custom field ID.
+
+        Returns:
+            Paginated list of matching :class:`Document` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
         if ordering:
             params["ordering"] = ordering
@@ -64,6 +79,17 @@ class DocumentsClient:
         page_size: int = 25,
         more_like: int | None = None,
     ) -> Paginated[Document]:
+        """Full-text search for documents.
+
+        Args:
+            query: Search query string.
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            more_like: Return documents similar to this document ID.
+
+        Returns:
+            Paginated list of matching :class:`Document` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
         if more_like is not None:
             params["more_like_id"] = more_like
@@ -73,42 +99,115 @@ class DocumentsClient:
         return Paginated[Document].model_validate(body)
 
     async def get(self, document_id: int) -> Document:
+        """Fetch a single document by ID.
+
+        Args:
+            document_id: ID of the document to retrieve.
+
+        Returns:
+            The matching :class:`Document`.
+        """
         body = await self._http.get_json(f"/api/documents/{document_id}/")
         return Document.model_validate(body)
 
     async def get_content(self, document_id: int) -> str:
+        """Return the plain-text content of a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            Extracted text content, or an empty string if none.
+        """
         doc = await self.get(document_id)
         return doc.content or ""
 
     async def get_thumbnail(self, document_id: int) -> tuple[bytes, str]:
+        """Download the thumbnail image for a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            Tuple of ``(image_bytes, content_type)``.
+        """
         return await self._http.stream_bytes(f"/api/documents/{document_id}/thumb/")
 
     async def get_preview(self, document_id: int) -> tuple[bytes, str]:
+        """Download the preview PDF for a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            Tuple of ``(pdf_bytes, content_type)``.
+        """
         return await self._http.stream_bytes(f"/api/documents/{document_id}/preview/")
 
     async def download(
         self, document_id: int, *, original: bool = False
     ) -> tuple[bytes, str]:
+        """Download the document file.
+
+        Args:
+            document_id: ID of the document.
+            original: If ``True``, download the original (unarchived) file.
+
+        Returns:
+            Tuple of ``(file_bytes, content_type)``.
+        """
         params = {"original": "true"} if original else None
         return await self._http.stream_bytes(
             f"/api/documents/{document_id}/download/", params=params
         )
 
     async def get_metadata(self, document_id: int) -> DocumentMetadata:
+        """Fetch metadata for a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            :class:`DocumentMetadata` for the document.
+        """
         body = await self._http.get_json(f"/api/documents/{document_id}/metadata/")
         return DocumentMetadata.model_validate(body)
 
     async def get_notes(self, document_id: int) -> builtins.list[DocumentNote]:
+        """List all notes attached to a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            List of :class:`DocumentNote` objects, oldest first.
+        """
         body = await self._http.get_json(f"/api/documents/{document_id}/notes/")
         return [DocumentNote.model_validate(n) for n in body]
 
     async def get_history(
         self, document_id: int
     ) -> builtins.list[DocumentHistoryEntry]:
+        """Fetch the audit history for a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            List of :class:`DocumentHistoryEntry` objects.
+        """
         body = await self._http.get_json(f"/api/documents/{document_id}/history/")
         return [DocumentHistoryEntry.model_validate(h) for h in body]
 
     async def get_suggestions(self, document_id: int) -> DocumentSuggestions:
+        """Fetch classifier suggestions for a document.
+
+        Args:
+            document_id: ID of the document.
+
+        Returns:
+            :class:`DocumentSuggestions` with tag, correspondent, and type hints.
+        """
         body = await self._http.get_json(f"/api/documents/{document_id}/suggestions/")
         return DocumentSuggestions.model_validate(body)
 

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import builtins
+from collections.abc import Sequence
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import (
     BulkEditOperation,
@@ -20,6 +23,8 @@ from paperless_mcp.models.document import (
 
 
 class DocumentsClient:
+    """Async operations against ``/api/documents/``."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
@@ -29,7 +34,7 @@ class DocumentsClient:
         page: int = 1,
         page_size: int = 25,
         ordering: str | None = None,
-        tags: list[int] | None = None,
+        tags: Sequence[int] | None = None,
         correspondent: int | None = None,
         document_type: int | None = None,
         storage_path: int | None = None,
@@ -38,7 +43,7 @@ class DocumentsClient:
         params: dict[str, object] = {"page": page, "page_size": page_size}
         if ordering:
             params["ordering"] = ordering
-        if tags:
+        if tags is not None:
             params["tags__id__in"] = ",".join(str(t) for t in tags)
         if correspondent is not None:
             params["correspondent__id"] = correspondent
@@ -93,11 +98,13 @@ class DocumentsClient:
         body = await self._http.get_json(f"/api/documents/{document_id}/metadata/")
         return DocumentMetadata.model_validate(body)
 
-    async def get_notes(self, document_id: int) -> list[DocumentNote]:
+    async def get_notes(self, document_id: int) -> builtins.list[DocumentNote]:
         body = await self._http.get_json(f"/api/documents/{document_id}/notes/")
         return [DocumentNote.model_validate(n) for n in body]
 
-    async def get_history(self, document_id: int) -> list[DocumentHistoryEntry]:
+    async def get_history(
+        self, document_id: int
+    ) -> builtins.list[DocumentHistoryEntry]:
         body = await self._http.get_json(f"/api/documents/{document_id}/history/")
         return [DocumentHistoryEntry.model_validate(h) for h in body]
 
@@ -137,10 +144,10 @@ class DocumentsClient:
         title: str | None = None,
         correspondent: int | None = None,
         document_type: int | None = None,
-        tags: list[int] | None = None,
+        tags: Sequence[int] | None = None,
         created: str | None = None,
         archive_serial_number: str | int | None = None,
-        custom_fields: list[int] | None = None,
+        custom_fields: Sequence[int] | None = None,
     ) -> UploadTaskAcknowledgement:
         """Upload a new document via multipart form POST.
 
@@ -158,7 +165,9 @@ class DocumentsClient:
         Returns:
             An :class:`UploadTaskAcknowledgement` containing the task UUID.
         """
-        files = {"document": (filename, content, "application/octet-stream")}
+        files: dict[str, object] = {
+            "document": (filename, content, "application/octet-stream")
+        }
         data: dict[str, object] = {}
         if title is not None:
             data["title"] = title
@@ -166,27 +175,18 @@ class DocumentsClient:
             data["correspondent"] = correspondent
         if document_type is not None:
             data["document_type"] = document_type
-        if tags:
+        if tags is not None:
             data["tags"] = [str(t) for t in tags]
         if created is not None:
             data["created"] = created
         if archive_serial_number is not None:
             data["archive_serial_number"] = str(archive_serial_number)
-        if custom_fields:
+        if custom_fields is not None:
             data["custom_fields"] = [str(cf) for cf in custom_fields]
 
-        response = await self._http._client.request(
-            "POST",
-            "/api/documents/post_document/",
-            data=data,
-            files=files,
+        body = await self._http.upload_multipart(
+            "/api/documents/post_document/", data=data, files=files
         )
-        if not response.is_success:
-            from paperless_mcp.client._errors import error_from_response
-
-            raise error_from_response(response)
-
-        body = response.json()
         if isinstance(body, str):
             return UploadTaskAcknowledgement(task_id=body)
         if isinstance(body, dict) and "task_id" in body:
@@ -197,7 +197,7 @@ class DocumentsClient:
     async def bulk_edit(
         self,
         *,
-        document_ids: list[int],
+        document_ids: Sequence[int],
         method: BulkEditOperation,
         parameters: dict[str, object] | None = None,
     ) -> BulkEditResult:
@@ -236,7 +236,7 @@ class DocumentsClient:
         if not notes:
             msg = "add_note: empty notes list returned"
             raise RuntimeError(msg)
-        return notes[0]
+        return notes[-1]
 
     async def delete_note(self, document_id: int, note_id: int) -> None:
         """Delete a note from a document.
@@ -245,4 +245,6 @@ class DocumentsClient:
             document_id: ID of the document.
             note_id: ID of the note to delete.
         """
-        await self._http.delete(f"/api/documents/{document_id}/notes/?id={note_id}")
+        await self._http.delete(
+            f"/api/documents/{document_id}/notes/", params={"id": note_id}
+        )

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -1,0 +1,61 @@
+"""Documents resource client for Paperless-NGX."""
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.document import Document, DocumentHistoryEntry, DocumentMetadata, DocumentNote, DocumentSuggestions
+
+class DocumentsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 25, ordering: str | None = None, tags: list[int] | None = None, correspondent: int | None = None, document_type: int | None = None, storage_path: int | None = None, custom_field: int | None = None) -> Paginated[Document]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        if tags: params["tags__id__in"] = ",".join(str(t) for t in tags)
+        if correspondent is not None: params["correspondent__id"] = correspondent
+        if document_type is not None: params["document_type__id"] = document_type
+        if storage_path is not None: params["storage_path__id"] = storage_path
+        if custom_field is not None: params["custom_fields__id"] = custom_field
+        body = await self._http.get_json("/api/documents/", params=params)
+        return Paginated[Document].model_validate(body)
+
+    async def search(self, query: str, *, page: int = 1, page_size: int = 25, more_like: int | None = None) -> Paginated[Document]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if more_like is not None: params["more_like_id"] = more_like
+        if query: params["query"] = query
+        body = await self._http.get_json("/api/documents/", params=params)
+        return Paginated[Document].model_validate(body)
+
+    async def get(self, document_id: int) -> Document:
+        body = await self._http.get_json(f"/api/documents/{document_id}/")
+        return Document.model_validate(body)
+
+    async def get_content(self, document_id: int) -> str:
+        doc = await self.get(document_id)
+        return doc.content or ""
+
+    async def get_thumbnail(self, document_id: int) -> tuple[bytes, str]:
+        return await self._http.stream_bytes(f"/api/documents/{document_id}/thumb/")
+
+    async def get_preview(self, document_id: int) -> tuple[bytes, str]:
+        return await self._http.stream_bytes(f"/api/documents/{document_id}/preview/")
+
+    async def download(self, document_id: int, *, original: bool = False) -> tuple[bytes, str]:
+        params = {"original": "true"} if original else None
+        return await self._http.stream_bytes(f"/api/documents/{document_id}/download/", params=params)
+
+    async def get_metadata(self, document_id: int) -> DocumentMetadata:
+        body = await self._http.get_json(f"/api/documents/{document_id}/metadata/")
+        return DocumentMetadata.model_validate(body)
+
+    async def get_notes(self, document_id: int) -> list[DocumentNote]:
+        body = await self._http.get_json(f"/api/documents/{document_id}/notes/")
+        return [DocumentNote.model_validate(n) for n in body]
+
+    async def get_history(self, document_id: int) -> list[DocumentHistoryEntry]:
+        body = await self._http.get_json(f"/api/documents/{document_id}/history/")
+        return [DocumentHistoryEntry.model_validate(h) for h in body]
+
+    async def get_suggestions(self, document_id: int) -> DocumentSuggestions:
+        body = await self._http.get_json(f"/api/documents/{document_id}/suggestions/")
+        return DocumentSuggestions.model_validate(body)

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -18,25 +18,52 @@ from paperless_mcp.models.document import (
     DocumentSuggestions,
 )
 
+
 class DocumentsClient:
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 25, ordering: str | None = None, tags: list[int] | None = None, correspondent: int | None = None, document_type: int | None = None, storage_path: int | None = None, custom_field: int | None = None) -> Paginated[Document]:
+    async def list(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 25,
+        ordering: str | None = None,
+        tags: list[int] | None = None,
+        correspondent: int | None = None,
+        document_type: int | None = None,
+        storage_path: int | None = None,
+        custom_field: int | None = None,
+    ) -> Paginated[Document]:
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
-        if tags: params["tags__id__in"] = ",".join(str(t) for t in tags)
-        if correspondent is not None: params["correspondent__id"] = correspondent
-        if document_type is not None: params["document_type__id"] = document_type
-        if storage_path is not None: params["storage_path__id"] = storage_path
-        if custom_field is not None: params["custom_fields__id"] = custom_field
+        if ordering:
+            params["ordering"] = ordering
+        if tags:
+            params["tags__id__in"] = ",".join(str(t) for t in tags)
+        if correspondent is not None:
+            params["correspondent__id"] = correspondent
+        if document_type is not None:
+            params["document_type__id"] = document_type
+        if storage_path is not None:
+            params["storage_path__id"] = storage_path
+        if custom_field is not None:
+            params["custom_fields__id"] = custom_field
         body = await self._http.get_json("/api/documents/", params=params)
         return Paginated[Document].model_validate(body)
 
-    async def search(self, query: str, *, page: int = 1, page_size: int = 25, more_like: int | None = None) -> Paginated[Document]:
+    async def search(
+        self,
+        query: str,
+        *,
+        page: int = 1,
+        page_size: int = 25,
+        more_like: int | None = None,
+    ) -> Paginated[Document]:
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if more_like is not None: params["more_like_id"] = more_like
-        if query: params["query"] = query
+        if more_like is not None:
+            params["more_like_id"] = more_like
+        if query:
+            params["query"] = query
         body = await self._http.get_json("/api/documents/", params=params)
         return Paginated[Document].model_validate(body)
 
@@ -54,9 +81,13 @@ class DocumentsClient:
     async def get_preview(self, document_id: int) -> tuple[bytes, str]:
         return await self._http.stream_bytes(f"/api/documents/{document_id}/preview/")
 
-    async def download(self, document_id: int, *, original: bool = False) -> tuple[bytes, str]:
+    async def download(
+        self, document_id: int, *, original: bool = False
+    ) -> tuple[bytes, str]:
         params = {"original": "true"} if original else None
-        return await self._http.stream_bytes(f"/api/documents/{document_id}/download/", params=params)
+        return await self._http.stream_bytes(
+            f"/api/documents/{document_id}/download/", params=params
+        )
 
     async def get_metadata(self, document_id: int) -> DocumentMetadata:
         body = await self._http.get_json(f"/api/documents/{document_id}/metadata/")
@@ -214,6 +245,4 @@ class DocumentsClient:
             document_id: ID of the document.
             note_id: ID of the note to delete.
         """
-        await self._http.delete(
-            f"/api/documents/{document_id}/notes/?id={note_id}"
-        )
+        await self._http.delete(f"/api/documents/{document_id}/notes/?id={note_id}")

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -1,8 +1,22 @@
 """Documents resource client for Paperless-NGX."""
+
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import Paginated
-from paperless_mcp.models.document import Document, DocumentHistoryEntry, DocumentMetadata, DocumentNote, DocumentSuggestions
+from paperless_mcp.models.common import (
+    BulkEditOperation,
+    BulkEditResult,
+    Paginated,
+    UploadTaskAcknowledgement,
+)
+from paperless_mcp.models.document import (
+    Document,
+    DocumentHistoryEntry,
+    DocumentMetadata,
+    DocumentNote,
+    DocumentPatch,
+    DocumentSuggestions,
+)
 
 class DocumentsClient:
     def __init__(self, http: PaperlessHTTP) -> None:
@@ -59,3 +73,147 @@ class DocumentsClient:
     async def get_suggestions(self, document_id: int) -> DocumentSuggestions:
         body = await self._http.get_json(f"/api/documents/{document_id}/suggestions/")
         return DocumentSuggestions.model_validate(body)
+
+    async def update(self, document_id: int, patch: DocumentPatch) -> Document:
+        """Partially update a document via PATCH.
+
+        Args:
+            document_id: ID of the document to update.
+            patch: Fields to update; unset fields are excluded from the payload.
+
+        Returns:
+            The updated Document.
+        """
+        payload = patch.model_dump(exclude_unset=True, mode="json")
+        body = await self._http.patch_json(
+            f"/api/documents/{document_id}/", json=payload
+        )
+        return Document.model_validate(body)
+
+    async def delete(self, document_id: int) -> None:
+        """Delete a document by ID.
+
+        Args:
+            document_id: ID of the document to delete.
+        """
+        await self._http.delete(f"/api/documents/{document_id}/")
+
+    async def upload(
+        self,
+        *,
+        filename: str,
+        content: bytes,
+        title: str | None = None,
+        correspondent: int | None = None,
+        document_type: int | None = None,
+        tags: list[int] | None = None,
+        created: str | None = None,
+        archive_serial_number: str | int | None = None,
+        custom_fields: list[int] | None = None,
+    ) -> UploadTaskAcknowledgement:
+        """Upload a new document via multipart form POST.
+
+        Args:
+            filename: Original filename to attach to the upload.
+            content: Raw document bytes.
+            title: Optional title to set on the document.
+            correspondent: Optional correspondent ID.
+            document_type: Optional document type ID.
+            tags: Optional list of tag IDs.
+            created: Optional ISO-8601 created date string.
+            archive_serial_number: Optional archive serial number.
+            custom_fields: Optional list of custom field IDs.
+
+        Returns:
+            An :class:`UploadTaskAcknowledgement` containing the task UUID.
+        """
+        files = {"document": (filename, content, "application/octet-stream")}
+        data: dict[str, object] = {}
+        if title is not None:
+            data["title"] = title
+        if correspondent is not None:
+            data["correspondent"] = correspondent
+        if document_type is not None:
+            data["document_type"] = document_type
+        if tags:
+            data["tags"] = [str(t) for t in tags]
+        if created is not None:
+            data["created"] = created
+        if archive_serial_number is not None:
+            data["archive_serial_number"] = str(archive_serial_number)
+        if custom_fields:
+            data["custom_fields"] = [str(cf) for cf in custom_fields]
+
+        response = await self._http._client.request(
+            "POST",
+            "/api/documents/post_document/",
+            data=data,
+            files=files,
+        )
+        if not response.is_success:
+            from paperless_mcp.client._errors import error_from_response
+
+            raise error_from_response(response)
+
+        body = response.json()
+        if isinstance(body, str):
+            return UploadTaskAcknowledgement(task_id=body)
+        if isinstance(body, dict) and "task_id" in body:
+            return UploadTaskAcknowledgement.model_validate(body)
+        msg = f"unexpected upload response shape: {body!r}"
+        raise TypeError(msg)
+
+    async def bulk_edit(
+        self,
+        *,
+        document_ids: list[int],
+        method: BulkEditOperation,
+        parameters: dict[str, object] | None = None,
+    ) -> BulkEditResult:
+        """Perform a bulk edit operation on multiple documents.
+
+        Args:
+            document_ids: List of document IDs to act on.
+            method: The bulk edit operation to perform.
+            parameters: Optional extra parameters for the operation.
+
+        Returns:
+            A :class:`BulkEditResult` with the operation result.
+        """
+        payload: dict[str, object] = {
+            "documents": document_ids,
+            "method": method.value,
+            "parameters": parameters or {},
+        }
+        body = await self._http.post_json("/api/documents/bulk_edit/", json=payload)
+        return BulkEditResult.model_validate(body)
+
+    async def add_note(self, document_id: int, note: str) -> DocumentNote:
+        """Add a note to a document.
+
+        Args:
+            document_id: ID of the document.
+            note: Text content of the note.
+
+        Returns:
+            The newly created :class:`DocumentNote`.
+        """
+        body = await self._http.post_json(
+            f"/api/documents/{document_id}/notes/", json={"note": note}
+        )
+        notes = [DocumentNote.model_validate(n) for n in body]
+        if not notes:
+            msg = "add_note: empty notes list returned"
+            raise RuntimeError(msg)
+        return notes[0]
+
+    async def delete_note(self, document_id: int, note_id: int) -> None:
+        """Delete a note from a document.
+
+        Args:
+            document_id: ID of the document.
+            note_id: ID of the note to delete.
+        """
+        await self._http.delete(
+            f"/api/documents/{document_id}/notes/?id={note_id}"
+        )

--- a/src/paperless_mcp/client/saved_views.py
+++ b/src/paperless_mcp/client/saved_views.py
@@ -16,11 +16,28 @@ class SavedViewsClient:
     async def list(
         self, *, page: int = 1, page_size: int = 100
     ) -> Paginated[SavedView]:
+        """List saved views.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+
+        Returns:
+            Paginated list of :class:`SavedView` objects.
+        """
         body = await self._http.get_json(
             "/api/saved_views/", params={"page": page, "page_size": page_size}
         )
         return Paginated[SavedView].model_validate(body)
 
     async def get(self, view_id: int) -> SavedView:
+        """Fetch a single saved view by ID.
+
+        Args:
+            view_id: ID of the saved view.
+
+        Returns:
+            The matching :class:`SavedView`.
+        """
         body = await self._http.get_json(f"/api/saved_views/{view_id}/")
         return SavedView.model_validate(body)

--- a/src/paperless_mcp/client/saved_views.py
+++ b/src/paperless_mcp/client/saved_views.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.saved_view import SavedView
+
+class SavedViewsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100) -> Paginated[SavedView]:
+        body = await self._http.get_json("/api/saved_views/", params={"page": page, "page_size": page_size})
+        return Paginated[SavedView].model_validate(body)
+
+    async def get(self, view_id: int) -> SavedView:
+        body = await self._http.get_json(f"/api/saved_views/{view_id}/")
+        return SavedView.model_validate(body)

--- a/src/paperless_mcp/client/saved_views.py
+++ b/src/paperless_mcp/client/saved_views.py
@@ -1,3 +1,5 @@
+"""Saved views resource client."""
+
 from __future__ import annotations
 
 from paperless_mcp.client._http import PaperlessHTTP
@@ -6,6 +8,8 @@ from paperless_mcp.models.saved_view import SavedView
 
 
 class SavedViewsClient:
+    """Async operations against ``/api/saved_views/``."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 

--- a/src/paperless_mcp/client/saved_views.py
+++ b/src/paperless_mcp/client/saved_views.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.saved_view import SavedView
+
 
 class SavedViewsClient:
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100) -> Paginated[SavedView]:
-        body = await self._http.get_json("/api/saved_views/", params={"page": page, "page_size": page_size})
+    async def list(
+        self, *, page: int = 1, page_size: int = 100
+    ) -> Paginated[SavedView]:
+        body = await self._http.get_json(
+            "/api/saved_views/", params={"page": page, "page_size": page_size}
+        )
         return Paginated[SavedView].model_validate(body)
 
     async def get(self, view_id: int) -> SavedView:

--- a/src/paperless_mcp/client/share_links.py
+++ b/src/paperless_mcp/client/share_links.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.share_link import ShareLink
+
+class ShareLinksClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, document_id: int | None = None) -> Paginated[ShareLink]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if document_id is not None: params["document"] = document_id
+        body = await self._http.get_json("/api/share_links/", params=params)
+        return Paginated[ShareLink].model_validate(body)
+
+    async def get(self, share_link_id: int) -> ShareLink:
+        body = await self._http.get_json(f"/api/share_links/{share_link_id}/")
+        return ShareLink.model_validate(body)

--- a/src/paperless_mcp/client/share_links.py
+++ b/src/paperless_mcp/client/share_links.py
@@ -1,3 +1,5 @@
+"""Share links resource client."""
+
 from __future__ import annotations
 
 from paperless_mcp.client._http import PaperlessHTTP
@@ -6,6 +8,8 @@ from paperless_mcp.models.share_link import ShareLink
 
 
 class ShareLinksClient:
+    """Async operations against ``/api/share_links/``."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 

--- a/src/paperless_mcp/client/share_links.py
+++ b/src/paperless_mcp/client/share_links.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.share_link import ShareLink
+
 
 class ShareLinksClient:
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, document_id: int | None = None) -> Paginated[ShareLink]:
+    async def list(
+        self, *, page: int = 1, page_size: int = 100, document_id: int | None = None
+    ) -> Paginated[ShareLink]:
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if document_id is not None: params["document"] = document_id
+        if document_id is not None:
+            params["document"] = document_id
         body = await self._http.get_json("/api/share_links/", params=params)
         return Paginated[ShareLink].model_validate(body)
 

--- a/src/paperless_mcp/client/share_links.py
+++ b/src/paperless_mcp/client/share_links.py
@@ -16,6 +16,16 @@ class ShareLinksClient:
     async def list(
         self, *, page: int = 1, page_size: int = 100, document_id: int | None = None
     ) -> Paginated[ShareLink]:
+        """List share links, optionally filtered by document.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            document_id: Filter to share links for this document ID.
+
+        Returns:
+            Paginated list of :class:`ShareLink` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
         if document_id is not None:
             params["document"] = document_id
@@ -23,5 +33,13 @@ class ShareLinksClient:
         return Paginated[ShareLink].model_validate(body)
 
     async def get(self, share_link_id: int) -> ShareLink:
+        """Fetch a single share link by ID.
+
+        Args:
+            share_link_id: ID of the share link.
+
+        Returns:
+            The matching :class:`ShareLink`.
+        """
         body = await self._http.get_json(f"/api/share_links/{share_link_id}/")
         return ShareLink.model_validate(body)

--- a/src/paperless_mcp/client/storage_paths.py
+++ b/src/paperless_mcp/client/storage_paths.py
@@ -1,3 +1,5 @@
+"""Storage paths resource client."""
+
 from __future__ import annotations
 
 from paperless_mcp.client._http import PaperlessHTTP
@@ -6,6 +8,8 @@ from paperless_mcp.models.storage_path import StoragePath
 
 
 class StoragePathsClient:
+    """Async operations against ``/api/storage_paths/``."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 

--- a/src/paperless_mcp/client/storage_paths.py
+++ b/src/paperless_mcp/client/storage_paths.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.storage_path import StoragePath
+
 
 class StoragePathsClient:
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None) -> Paginated[StoragePath]:
+    async def list(
+        self, *, page: int = 1, page_size: int = 100, ordering: str | None = None
+    ) -> Paginated[StoragePath]:
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
+        if ordering:
+            params["ordering"] = ordering
         body = await self._http.get_json("/api/storage_paths/", params=params)
         return Paginated[StoragePath].model_validate(body)
 

--- a/src/paperless_mcp/client/storage_paths.py
+++ b/src/paperless_mcp/client/storage_paths.py
@@ -16,6 +16,16 @@ class StoragePathsClient:
     async def list(
         self, *, page: int = 1, page_size: int = 100, ordering: str | None = None
     ) -> Paginated[StoragePath]:
+        """List storage paths.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field name to order by (prefix with ``-`` for descending).
+
+        Returns:
+            Paginated list of :class:`StoragePath` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
         if ordering:
             params["ordering"] = ordering
@@ -23,5 +33,13 @@ class StoragePathsClient:
         return Paginated[StoragePath].model_validate(body)
 
     async def get(self, storage_path_id: int) -> StoragePath:
+        """Fetch a single storage path by ID.
+
+        Args:
+            storage_path_id: ID of the storage path.
+
+        Returns:
+            The matching :class:`StoragePath`.
+        """
         body = await self._http.get_json(f"/api/storage_paths/{storage_path_id}/")
         return StoragePath.model_validate(body)

--- a/src/paperless_mcp/client/storage_paths.py
+++ b/src/paperless_mcp/client/storage_paths.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.storage_path import StoragePath
+
+class StoragePathsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None) -> Paginated[StoragePath]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        body = await self._http.get_json("/api/storage_paths/", params=params)
+        return Paginated[StoragePath].model_validate(body)
+
+    async def get(self, storage_path_id: int) -> StoragePath:
+        body = await self._http.get_json(f"/api/storage_paths/{storage_path_id}/")
+        return StoragePath.model_validate(body)

--- a/src/paperless_mcp/client/system.py
+++ b/src/paperless_mcp/client/system.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.system import RemoteVersion, Statistics
+
+class SystemClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def statistics(self) -> Statistics:
+        body = await self._http.get_json("/api/statistics/")
+        return Statistics.model_validate(body)
+
+    async def remote_version(self) -> RemoteVersion:
+        body = await self._http.get_json("/api/remote_version/")
+        return RemoteVersion.model_validate(body)

--- a/src/paperless_mcp/client/system.py
+++ b/src/paperless_mcp/client/system.py
@@ -13,9 +13,19 @@ class SystemClient:
         self._http = http
 
     async def statistics(self) -> Statistics:
+        """Fetch document and storage statistics from Paperless-NGX.
+
+        Returns:
+            :class:`Statistics` with counts and storage metrics.
+        """
         body = await self._http.get_json("/api/statistics/")
         return Statistics.model_validate(body)
 
     async def remote_version(self) -> RemoteVersion:
+        """Fetch the latest available Paperless-NGX version from the remote.
+
+        Returns:
+            :class:`RemoteVersion` with current and latest version strings.
+        """
         body = await self._http.get_json("/api/remote_version/")
         return RemoteVersion.model_validate(body)

--- a/src/paperless_mcp/client/system.py
+++ b/src/paperless_mcp/client/system.py
@@ -1,3 +1,5 @@
+"""System resource client for Paperless-NGX statistics and version info."""
+
 from __future__ import annotations
 
 from paperless_mcp.client._http import PaperlessHTTP
@@ -5,6 +7,8 @@ from paperless_mcp.models.system import RemoteVersion, Statistics
 
 
 class SystemClient:
+    """Async operations against Paperless-NGX system endpoints."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 

--- a/src/paperless_mcp/client/system.py
+++ b/src/paperless_mcp/client/system.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.system import RemoteVersion, Statistics
+
 
 class SystemClient:
     def __init__(self, http: PaperlessHTTP) -> None:

--- a/src/paperless_mcp/client/tags.py
+++ b/src/paperless_mcp/client/tags.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.common import BulkEditResult, Paginated
 from paperless_mcp.models.tag import Tag, TagCreate, TagPatch
@@ -93,7 +95,7 @@ class TagsClient:
         self,
         *,
         operation: str,
-        ids: list[int],
+        ids: Sequence[int],
         parameters: dict[str, object] | None = None,
     ) -> BulkEditResult:
         """Perform a bulk edit operation on multiple tags.

--- a/src/paperless_mcp/client/tags.py
+++ b/src/paperless_mcp/client/tags.py
@@ -1,19 +1,116 @@
+"""Tags resource client."""
+
 from __future__ import annotations
+
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import Paginated
-from paperless_mcp.models.tag import Tag
+from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.tag import Tag, TagCreate, TagPatch
+
 
 class TagsClient:
+    """Async operations against ``/api/tags/``."""
+
+    _OBJECT_TYPE = "tags"
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[Tag]:
+    async def list(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 100,
+        ordering: str | None = None,
+        name__icontains: str | None = None,
+    ) -> Paginated[Tag]:
+        """List tags with optional filtering.
+
+        Args:
+            page: Page number (1-based).
+            page_size: Number of results per page.
+            ordering: Field to order by.
+            name__icontains: Filter tags whose name contains this string.
+
+        Returns:
+            A paginated list of :class:`Tag` objects.
+        """
         params: dict[str, object] = {"page": page, "page_size": page_size}
-        if ordering: params["ordering"] = ordering
-        if name__icontains: params["name__icontains"] = name__icontains
+        if ordering:
+            params["ordering"] = ordering
+        if name__icontains:
+            params["name__icontains"] = name__icontains
         body = await self._http.get_json("/api/tags/", params=params)
         return Paginated[Tag].model_validate(body)
 
     async def get(self, tag_id: int) -> Tag:
+        """Fetch a single tag by ID.
+
+        Args:
+            tag_id: ID of the tag to fetch.
+
+        Returns:
+            The :class:`Tag` with the given ID.
+        """
         body = await self._http.get_json(f"/api/tags/{tag_id}/")
         return Tag.model_validate(body)
+
+    async def create(self, body: TagCreate) -> Tag:
+        """Create a new tag.
+
+        Args:
+            body: Tag creation payload.
+
+        Returns:
+            The newly created :class:`Tag`.
+        """
+        payload = body.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.post_json("/api/tags/", json=payload)
+        return Tag.model_validate(response)
+
+    async def update(self, tag_id: int, patch: TagPatch) -> Tag:
+        """Partially update a tag via PATCH.
+
+        Args:
+            tag_id: ID of the tag to update.
+            patch: Fields to update; unset fields are excluded from the payload.
+
+        Returns:
+            The updated :class:`Tag`.
+        """
+        payload = patch.model_dump(exclude_unset=True, mode="json")
+        response = await self._http.patch_json(f"/api/tags/{tag_id}/", json=payload)
+        return Tag.model_validate(response)
+
+    async def delete(self, tag_id: int) -> None:
+        """Delete a tag by ID.
+
+        Args:
+            tag_id: ID of the tag to delete.
+        """
+        await self._http.delete(f"/api/tags/{tag_id}/")
+
+    async def bulk_edit(
+        self,
+        *,
+        operation: str,
+        ids: list[int],
+        parameters: dict[str, object] | None = None,
+    ) -> BulkEditResult:
+        """Perform a bulk edit operation on multiple tags.
+
+        Args:
+            operation: The operation to perform (e.g. ``"set_permissions"``).
+            ids: List of tag IDs to act on.
+            parameters: Optional extra parameters for the operation.
+
+        Returns:
+            A :class:`BulkEditResult` with the operation result.
+        """
+        payload: dict[str, object] = {
+            "object_type": self._OBJECT_TYPE,
+            "objects": ids,
+            "operation": operation,
+            "parameters": parameters or {},
+        }
+        body = await self._http.post_json("/api/bulk_edit_objects/", json=payload)
+        return BulkEditResult.model_validate(body)

--- a/src/paperless_mcp/client/tags.py
+++ b/src/paperless_mcp/client/tags.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.tag import Tag
+
+class TagsClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, page: int = 1, page_size: int = 100, ordering: str | None = None, name__icontains: str | None = None) -> Paginated[Tag]:
+        params: dict[str, object] = {"page": page, "page_size": page_size}
+        if ordering: params["ordering"] = ordering
+        if name__icontains: params["name__icontains"] = name__icontains
+        body = await self._http.get_json("/api/tags/", params=params)
+        return Paginated[Tag].model_validate(body)
+
+    async def get(self, tag_id: int) -> Tag:
+        body = await self._http.get_json(f"/api/tags/{tag_id}/")
+        return Tag.model_validate(body)

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -1,6 +1,9 @@
+"""Tasks resource client."""
+
 from __future__ import annotations
 
 import asyncio
+import builtins
 import time
 
 from paperless_mcp.client._http import PaperlessHTTP
@@ -10,24 +13,43 @@ _TERMINAL_STATUSES = {TaskStatus.SUCCESS, TaskStatus.FAILURE, TaskStatus.REVOKED
 
 
 class TasksClient:
+    """Async operations against ``/api/tasks/``."""
+
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
     async def list(
         self, *, status: TaskStatus | None = None, acknowledged: bool | None = None
-    ) -> list[Task]:
-        body = await self._http.get_json("/api/tasks/")
-        result = [Task.model_validate(entry) for entry in body]
+    ) -> builtins.list[Task]:
+        """List tasks with optional server-side filtering.
+
+        Args:
+            status: Filter by task status.
+            acknowledged: Filter by acknowledged flag.
+
+        Returns:
+            List of matching :class:`Task` objects.
+        """
+        params: dict[str, object] = {}
         if status is not None:
-            result = [t for t in result if t.status is status]
+            params["status"] = status.value
         if acknowledged is not None:
-            result = [t for t in result if t.acknowledged is acknowledged]
-        return result
+            params["acknowledged"] = str(acknowledged).lower()
+        body = await self._http.get_json("/api/tasks/", params=params or None)
+        return [Task.model_validate(entry) for entry in body]
 
     async def get(self, task_uuid: str) -> Task | None:
-        for task in await self.list():
-            if task.task_id == task_uuid:
-                return task
+        """Fetch a single task by UUID.
+
+        Args:
+            task_uuid: The task UUID to look up.
+
+        Returns:
+            The matching :class:`Task`, or ``None`` if not found.
+        """
+        body = await self._http.get_json("/api/tasks/", params={"task_id": task_uuid})
+        if body and isinstance(body, builtins.list):
+            return Task.model_validate(body[0])
         return None
 
     async def wait_for(
@@ -37,6 +59,19 @@ class TasksClient:
         timeout_seconds: float = 60.0,
         poll_seconds: float = 1.0,
     ) -> Task:
+        """Poll until a task reaches a terminal status.
+
+        Args:
+            task_uuid: UUID of the task to wait for.
+            timeout_seconds: Maximum time to wait before raising :exc:`TimeoutError`.
+            poll_seconds: Seconds between polls.
+
+        Returns:
+            The completed :class:`Task`.
+
+        Raises:
+            TimeoutError: If the task does not complete within ``timeout_seconds``.
+        """
         deadline = time.monotonic() + timeout_seconds
         while True:
             task = await self.get(task_uuid)

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -1,19 +1,27 @@
 from __future__ import annotations
-import asyncio, time
+
+import asyncio
+import time
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.models.task import Task, TaskStatus
 
 _TERMINAL_STATUSES = {TaskStatus.SUCCESS, TaskStatus.FAILURE, TaskStatus.REVOKED}
 
+
 class TasksClient:
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
 
-    async def list(self, *, status: TaskStatus | None = None, acknowledged: bool | None = None) -> list[Task]:
+    async def list(
+        self, *, status: TaskStatus | None = None, acknowledged: bool | None = None
+    ) -> list[Task]:
         body = await self._http.get_json("/api/tasks/")
         result = [Task.model_validate(entry) for entry in body]
-        if status is not None: result = [t for t in result if t.status is status]
-        if acknowledged is not None: result = [t for t in result if t.acknowledged is acknowledged]
+        if status is not None:
+            result = [t for t in result if t.status is status]
+        if acknowledged is not None:
+            result = [t for t in result if t.acknowledged is acknowledged]
         return result
 
     async def get(self, task_uuid: str) -> Task | None:
@@ -22,12 +30,20 @@ class TasksClient:
                 return task
         return None
 
-    async def wait_for(self, task_uuid: str, *, timeout_seconds: float = 60.0, poll_seconds: float = 1.0) -> Task:
+    async def wait_for(
+        self,
+        task_uuid: str,
+        *,
+        timeout_seconds: float = 60.0,
+        poll_seconds: float = 1.0,
+    ) -> Task:
         deadline = time.monotonic() + timeout_seconds
         while True:
             task = await self.get(task_uuid)
             if task is not None and task.status in _TERMINAL_STATUSES:
                 return task
             if time.monotonic() >= deadline:
-                raise TimeoutError(f"task {task_uuid} did not complete within {timeout_seconds}s")
+                raise TimeoutError(
+                    f"task {task_uuid} did not complete within {timeout_seconds}s"
+                )
             await asyncio.sleep(poll_seconds)

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import asyncio, time
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.task import Task, TaskStatus
+
+_TERMINAL_STATUSES = {TaskStatus.SUCCESS, TaskStatus.FAILURE, TaskStatus.REVOKED}
+
+class TasksClient:
+    def __init__(self, http: PaperlessHTTP) -> None:
+        self._http = http
+
+    async def list(self, *, status: TaskStatus | None = None, acknowledged: bool | None = None) -> list[Task]:
+        body = await self._http.get_json("/api/tasks/")
+        result = [Task.model_validate(entry) for entry in body]
+        if status is not None: result = [t for t in result if t.status is status]
+        if acknowledged is not None: result = [t for t in result if t.acknowledged is acknowledged]
+        return result
+
+    async def get(self, task_uuid: str) -> Task | None:
+        for task in await self.list():
+            if task.task_id == task_uuid:
+                return task
+        return None
+
+    async def wait_for(self, task_uuid: str, *, timeout_seconds: float = 60.0, poll_seconds: float = 1.0) -> Task:
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            task = await self.get(task_uuid)
+            if task is not None and task.status in _TERMINAL_STATUSES:
+                return task
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"task {task_uuid} did not complete within {timeout_seconds}s")
+            await asyncio.sleep(poll_seconds)

--- a/tests/unit/client/test_correspondents.py
+++ b/tests/unit/client/test_correspondents.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.correspondents import CorrespondentsClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def correspondents(http: PaperlessHTTP) -> CorrespondentsClient:
+    return CorrespondentsClient(http)
+
+@pytest.mark.asyncio
+async def test_list(correspondents: CorrespondentsClient, load_fixture) -> None:
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("correspondent.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/correspondents/").mock(return_value=httpx.Response(200, json=page))
+        result = await correspondents.list()
+    assert result.results[0].name == "ACME Corporation"
+
+@pytest.mark.asyncio
+async def test_get(correspondents: CorrespondentsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/correspondents/1/").mock(return_value=httpx.Response(200, json=load_fixture("correspondent.json")))
+        c = await correspondents.get(1)
+    assert c.id == 1

--- a/tests/unit/client/test_correspondents.py
+++ b/tests/unit/client/test_correspondents.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.correspondents import CorrespondentsClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def correspondents(http: PaperlessHTTP) -> CorrespondentsClient:
     return CorrespondentsClient(http)
 
+
 @pytest.mark.asyncio
 async def test_list(correspondents: CorrespondentsClient, load_fixture) -> None:
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("correspondent.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("correspondent.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/correspondents/").mock(return_value=httpx.Response(200, json=page))
+        mock.get("/api/correspondents/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         result = await correspondents.list()
     assert result.results[0].name == "ACME Corporation"
+
 
 @pytest.mark.asyncio
 async def test_get(correspondents: CorrespondentsClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/correspondents/1/").mock(return_value=httpx.Response(200, json=load_fixture("correspondent.json")))
+        mock.get("/api/correspondents/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("correspondent.json"))
+        )
         c = await correspondents.get(1)
     assert c.id == 1

--- a/tests/unit/client/test_correspondents_write.py
+++ b/tests/unit/client/test_correspondents_write.py
@@ -11,7 +11,9 @@ from paperless_mcp.models.correspondent import CorrespondentCreate, Corresponden
 
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
 
@@ -44,7 +46,9 @@ async def test_update(correspondents, load_fixture) -> None:
 @pytest.mark.asyncio
 async def test_delete(correspondents) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.delete("/api/correspondents/1/").mock(return_value=httpx.Response(204))
+        route = mock.delete("/api/correspondents/1/").mock(
+            return_value=httpx.Response(204)
+        )
         await correspondents.delete(1)
     assert route.called
 
@@ -58,4 +62,7 @@ async def test_bulk_edit(correspondents) -> None:
         result = await correspondents.bulk_edit(operation="set_permissions", ids=[1])
     assert result.result == "OK"
     import json
-    assert json.loads(route.calls.last.request.content)["object_type"] == "correspondents"
+
+    assert (
+        json.loads(route.calls.last.request.content)["object_type"] == "correspondents"
+    )

--- a/tests/unit/client/test_correspondents_write.py
+++ b/tests/unit/client/test_correspondents_write.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.correspondents import CorrespondentsClient
+from paperless_mcp.models.correspondent import CorrespondentCreate, CorrespondentPatch
+
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def correspondents(http: PaperlessHTTP) -> CorrespondentsClient:
+    return CorrespondentsClient(http)
+
+
+@pytest.mark.asyncio
+async def test_create(correspondents, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.post("/api/correspondents/").mock(
+            return_value=httpx.Response(201, json=load_fixture("correspondent.json"))
+        )
+        r = await correspondents.create(CorrespondentCreate(name="ACME"))
+    assert r.id == 1
+
+
+@pytest.mark.asyncio
+async def test_update(correspondents, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.patch("/api/correspondents/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("correspondent.json"))
+        )
+        r = await correspondents.update(1, CorrespondentPatch(name="Renamed"))
+    assert r.id == 1
+
+
+@pytest.mark.asyncio
+async def test_delete(correspondents) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/correspondents/1/").mock(return_value=httpx.Response(204))
+        await correspondents.delete(1)
+    assert route.called
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit(correspondents) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/bulk_edit_objects/").mock(
+            return_value=httpx.Response(200, json={"result": "OK"})
+        )
+        result = await correspondents.bulk_edit(operation="set_permissions", ids=[1])
+    assert result.result == "OK"
+    import json
+    assert json.loads(route.calls.last.request.content)["object_type"] == "correspondents"

--- a/tests/unit/client/test_correspondents_write.py
+++ b/tests/unit/client/test_correspondents_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -61,8 +63,6 @@ async def test_bulk_edit(correspondents) -> None:
         )
         result = await correspondents.bulk_edit(operation="set_permissions", ids=[1])
     assert result.result == "OK"
-    import json
-
     assert (
         json.loads(route.calls.last.request.content)["object_type"] == "correspondents"
     )

--- a/tests/unit/client/test_custom_fields.py
+++ b/tests/unit/client/test_custom_fields.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.custom_fields import CustomFieldsClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def custom_fields(http: PaperlessHTTP) -> CustomFieldsClient:
     return CustomFieldsClient(http)
 
+
 @pytest.mark.asyncio
 async def test_list(custom_fields: CustomFieldsClient, load_fixture) -> None:
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("custom_field.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("custom_field.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/custom_fields/").mock(return_value=httpx.Response(200, json=page))
+        mock.get("/api/custom_fields/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         result = await custom_fields.list()
     assert result.results[0].name == "Summary"
+
 
 @pytest.mark.asyncio
 async def test_get(custom_fields: CustomFieldsClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/custom_fields/2/").mock(return_value=httpx.Response(200, json=load_fixture("custom_field.json")))
+        mock.get("/api/custom_fields/2/").mock(
+            return_value=httpx.Response(200, json=load_fixture("custom_field.json"))
+        )
         cf = await custom_fields.get(2)
     assert cf.id == 2

--- a/tests/unit/client/test_custom_fields.py
+++ b/tests/unit/client/test_custom_fields.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.custom_fields import CustomFieldsClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def custom_fields(http: PaperlessHTTP) -> CustomFieldsClient:
+    return CustomFieldsClient(http)
+
+@pytest.mark.asyncio
+async def test_list(custom_fields: CustomFieldsClient, load_fixture) -> None:
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("custom_field.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/custom_fields/").mock(return_value=httpx.Response(200, json=page))
+        result = await custom_fields.list()
+    assert result.results[0].name == "Summary"
+
+@pytest.mark.asyncio
+async def test_get(custom_fields: CustomFieldsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/custom_fields/2/").mock(return_value=httpx.Response(200, json=load_fixture("custom_field.json")))
+        cf = await custom_fields.get(2)
+    assert cf.id == 2

--- a/tests/unit/client/test_custom_fields_write.py
+++ b/tests/unit/client/test_custom_fields_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -47,8 +49,6 @@ async def test_update(custom_fields, load_fixture) -> None:
         )
         r = await custom_fields.update(2, CustomFieldPatch(name="Renamed"))
     assert r.id == 2
-    import json
-
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
@@ -70,8 +70,6 @@ async def test_bulk_edit(custom_fields) -> None:
         )
         result = await custom_fields.bulk_edit(operation="set_permissions", ids=[2])
     assert result.result == "OK"
-    import json
-
     assert (
         json.loads(route.calls.last.request.content)["object_type"] == "custom_fields"
     )

--- a/tests/unit/client/test_custom_fields_write.py
+++ b/tests/unit/client/test_custom_fields_write.py
@@ -6,12 +6,18 @@ import respx
 
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.custom_fields import CustomFieldsClient
-from paperless_mcp.models.custom_field import CustomFieldCreate, CustomFieldDataType, CustomFieldPatch
+from paperless_mcp.models.custom_field import (
+    CustomFieldCreate,
+    CustomFieldDataType,
+    CustomFieldPatch,
+)
 
 
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
 
@@ -42,13 +48,16 @@ async def test_update(custom_fields, load_fixture) -> None:
         r = await custom_fields.update(2, CustomFieldPatch(name="Renamed"))
     assert r.id == 2
     import json
+
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
 @pytest.mark.asyncio
 async def test_delete(custom_fields) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.delete("/api/custom_fields/2/").mock(return_value=httpx.Response(204))
+        route = mock.delete("/api/custom_fields/2/").mock(
+            return_value=httpx.Response(204)
+        )
         await custom_fields.delete(2)
     assert route.called
 
@@ -62,4 +71,7 @@ async def test_bulk_edit(custom_fields) -> None:
         result = await custom_fields.bulk_edit(operation="set_permissions", ids=[2])
     assert result.result == "OK"
     import json
-    assert json.loads(route.calls.last.request.content)["object_type"] == "custom_fields"
+
+    assert (
+        json.loads(route.calls.last.request.content)["object_type"] == "custom_fields"
+    )

--- a/tests/unit/client/test_custom_fields_write.py
+++ b/tests/unit/client/test_custom_fields_write.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.custom_fields import CustomFieldsClient
+from paperless_mcp.models.custom_field import CustomFieldCreate, CustomFieldDataType, CustomFieldPatch
+
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def custom_fields(http: PaperlessHTTP) -> CustomFieldsClient:
+    return CustomFieldsClient(http)
+
+
+@pytest.mark.asyncio
+async def test_create(custom_fields, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.post("/api/custom_fields/").mock(
+            return_value=httpx.Response(201, json=load_fixture("custom_field.json"))
+        )
+        r = await custom_fields.create(
+            CustomFieldCreate(name="Summary", data_type=CustomFieldDataType.LONGTEXT)
+        )
+    assert r.id == 2
+
+
+@pytest.mark.asyncio
+async def test_update(custom_fields, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.patch("/api/custom_fields/2/").mock(
+            return_value=httpx.Response(200, json=load_fixture("custom_field.json"))
+        )
+        r = await custom_fields.update(2, CustomFieldPatch(name="Renamed"))
+    assert r.id == 2
+    import json
+    assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_delete(custom_fields) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/custom_fields/2/").mock(return_value=httpx.Response(204))
+        await custom_fields.delete(2)
+    assert route.called
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit(custom_fields) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/bulk_edit_objects/").mock(
+            return_value=httpx.Response(200, json={"result": "OK"})
+        )
+        result = await custom_fields.bulk_edit(operation="set_permissions", ids=[2])
+    assert result.result == "OK"
+    import json
+    assert json.loads(route.calls.last.request.content)["object_type"] == "custom_fields"

--- a/tests/unit/client/test_document_types.py
+++ b/tests/unit/client/test_document_types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.document_types import DocumentTypesClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def document_types(http: PaperlessHTTP) -> DocumentTypesClient:
+    return DocumentTypesClient(http)
+
+@pytest.mark.asyncio
+async def test_list(document_types: DocumentTypesClient, load_fixture) -> None:
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("document_type.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/document_types/").mock(return_value=httpx.Response(200, json=page))
+        result = await document_types.list()
+    assert result.results[0].name == "Invoice"
+
+@pytest.mark.asyncio
+async def test_get(document_types: DocumentTypesClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/document_types/3/").mock(return_value=httpx.Response(200, json=load_fixture("document_type.json")))
+        dt = await document_types.get(3)
+    assert dt.id == 3

--- a/tests/unit/client/test_document_types.py
+++ b/tests/unit/client/test_document_types.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.document_types import DocumentTypesClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def document_types(http: PaperlessHTTP) -> DocumentTypesClient:
     return DocumentTypesClient(http)
 
+
 @pytest.mark.asyncio
 async def test_list(document_types: DocumentTypesClient, load_fixture) -> None:
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("document_type.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("document_type.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/document_types/").mock(return_value=httpx.Response(200, json=page))
+        mock.get("/api/document_types/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         result = await document_types.list()
     assert result.results[0].name == "Invoice"
+
 
 @pytest.mark.asyncio
 async def test_get(document_types: DocumentTypesClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/document_types/3/").mock(return_value=httpx.Response(200, json=load_fixture("document_type.json")))
+        mock.get("/api/document_types/3/").mock(
+            return_value=httpx.Response(200, json=load_fixture("document_type.json"))
+        )
         dt = await document_types.get(3)
     assert dt.id == 3

--- a/tests/unit/client/test_document_types_write.py
+++ b/tests/unit/client/test_document_types_write.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.document_types import DocumentTypesClient
+from paperless_mcp.models.document_type import DocumentTypeCreate, DocumentTypePatch
+
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def document_types(http: PaperlessHTTP) -> DocumentTypesClient:
+    return DocumentTypesClient(http)
+
+
+@pytest.mark.asyncio
+async def test_create(document_types, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.post("/api/document_types/").mock(
+            return_value=httpx.Response(201, json=load_fixture("document_type.json"))
+        )
+        r = await document_types.create(DocumentTypeCreate(name="Invoice"))
+    assert r.id == 3
+
+
+@pytest.mark.asyncio
+async def test_update(document_types, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.patch("/api/document_types/3/").mock(
+            return_value=httpx.Response(200, json=load_fixture("document_type.json"))
+        )
+        r = await document_types.update(3, DocumentTypePatch(name="Renamed"))
+    assert r.id == 3
+    import json
+    assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_delete(document_types) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/document_types/3/").mock(return_value=httpx.Response(204))
+        await document_types.delete(3)
+    assert route.called
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit(document_types) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/bulk_edit_objects/").mock(
+            return_value=httpx.Response(200, json={"result": "OK"})
+        )
+        result = await document_types.bulk_edit(operation="set_permissions", ids=[3])
+    assert result.result == "OK"
+    import json
+    assert json.loads(route.calls.last.request.content)["object_type"] == "document_types"

--- a/tests/unit/client/test_document_types_write.py
+++ b/tests/unit/client/test_document_types_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -41,8 +43,6 @@ async def test_update(document_types, load_fixture) -> None:
         )
         r = await document_types.update(3, DocumentTypePatch(name="Renamed"))
     assert r.id == 3
-    import json
-
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
@@ -64,8 +64,6 @@ async def test_bulk_edit(document_types) -> None:
         )
         result = await document_types.bulk_edit(operation="set_permissions", ids=[3])
     assert result.result == "OK"
-    import json
-
     assert (
         json.loads(route.calls.last.request.content)["object_type"] == "document_types"
     )

--- a/tests/unit/client/test_document_types_write.py
+++ b/tests/unit/client/test_document_types_write.py
@@ -11,7 +11,9 @@ from paperless_mcp.models.document_type import DocumentTypeCreate, DocumentTypeP
 
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
 
@@ -40,13 +42,16 @@ async def test_update(document_types, load_fixture) -> None:
         r = await document_types.update(3, DocumentTypePatch(name="Renamed"))
     assert r.id == 3
     import json
+
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
 @pytest.mark.asyncio
 async def test_delete(document_types) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.delete("/api/document_types/3/").mock(return_value=httpx.Response(204))
+        route = mock.delete("/api/document_types/3/").mock(
+            return_value=httpx.Response(204)
+        )
         await document_types.delete(3)
     assert route.called
 
@@ -60,4 +65,7 @@ async def test_bulk_edit(document_types) -> None:
         result = await document_types.bulk_edit(operation="set_permissions", ids=[3])
     assert result.result == "OK"
     import json
-    assert json.loads(route.calls.last.request.content)["object_type"] == "document_types"
+
+    assert (
+        json.loads(route.calls.last.request.content)["object_type"] == "document_types"
+    )

--- a/tests/unit/client/test_documents_read.py
+++ b/tests/unit/client/test_documents_read.py
@@ -1,0 +1,98 @@
+"""Tests for DocumentsClient read operations."""
+from __future__ import annotations
+import httpx
+import pytest
+import respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.documents import DocumentsClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def documents(http: PaperlessHTTP) -> DocumentsClient:
+    return DocumentsClient(http)
+
+@pytest.mark.asyncio
+async def test_list_documents_passes_filters(documents: DocumentsClient, load_fixture) -> None:
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("document_minimal.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        result = await documents.list(page=2, page_size=50, tags=[1, 2], correspondent=7, document_type=3)
+    params = dict(route.calls.last.request.url.params)
+    assert params["page"] == "2"
+    assert params["page_size"] == "50"
+    assert params["tags__id__in"] == "1,2"
+    assert params["correspondent__id"] == "7"
+    assert params["document_type__id"] == "3"
+    assert result.results[0].id == 1
+
+@pytest.mark.asyncio
+async def test_search_uses_query_param(documents: DocumentsClient, load_fixture) -> None:
+    page = {"count": 0, "next": None, "previous": None, "results": []}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        await documents.search("hello world")
+    assert dict(route.calls.last.request.url.params)["query"] == "hello world"
+
+@pytest.mark.asyncio
+async def test_search_more_like_uses_more_like_id(documents: DocumentsClient, load_fixture) -> None:
+    page = {"count": 0, "next": None, "previous": None, "results": []}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        await documents.search("", more_like=42)
+    assert dict(route.calls.last.request.url.params)["more_like_id"] == "42"
+
+@pytest.mark.asyncio
+async def test_get_document(documents: DocumentsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/").mock(return_value=httpx.Response(200, json=load_fixture("document_minimal.json")))
+        doc = await documents.get(1)
+    assert doc.id == 1
+    assert doc.title == "Test Document"
+
+@pytest.mark.asyncio
+async def test_get_content(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/").mock(return_value=httpx.Response(200, json={"id": 1, "title": "x", "content": "OCR content here", "created": "2026-04-23T10:00:00Z", "tags": [], "notes": [], "custom_fields": []}))
+        content = await documents.get_content(1)
+    assert content == "OCR content here"
+
+@pytest.mark.asyncio
+async def test_get_thumbnail_returns_bytes(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/thumb/").mock(return_value=httpx.Response(200, content=b"\x89PNGfakebytes", headers={"content-type": "image/png"}))
+        data, content_type = await documents.get_thumbnail(1)
+    assert data.startswith(b"\x89PNG")
+    assert content_type == "image/png"
+
+@pytest.mark.asyncio
+async def test_get_metadata(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/metadata/").mock(return_value=httpx.Response(200, json={"original_checksum": "abc", "original_size": 12345, "original_mime_type": "application/pdf"}))
+        meta = await documents.get_metadata(1)
+    assert meta.original_checksum == "abc"
+
+@pytest.mark.asyncio
+async def test_get_notes(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/notes/").mock(return_value=httpx.Response(200, json=[{"id": 1, "note": "hi", "created": "2026-04-23T10:00:00Z", "user": 1}]))
+        notes = await documents.get_notes(1)
+    assert notes[0].note == "hi"
+
+@pytest.mark.asyncio
+async def test_get_history(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/history/").mock(return_value=httpx.Response(200, json=[{"timestamp": "2026-04-23T10:00:00Z", "action": "modify", "actor": "peter"}]))
+        hist = await documents.get_history(1)
+    assert hist[0].action == "modify"
+
+@pytest.mark.asyncio
+async def test_get_suggestions(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/documents/1/suggestions/").mock(return_value=httpx.Response(200, json={"correspondents": [7], "tags": [], "document_types": [], "dates": []}))
+        s = await documents.get_suggestions(1)
+    assert s.correspondents == [7]

--- a/tests/unit/client/test_documents_read.py
+++ b/tests/unit/client/test_documents_read.py
@@ -1,27 +1,46 @@
 """Tests for DocumentsClient read operations."""
+
 from __future__ import annotations
+
 import httpx
 import pytest
 import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.documents import DocumentsClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def documents(http: PaperlessHTTP) -> DocumentsClient:
     return DocumentsClient(http)
 
+
 @pytest.mark.asyncio
-async def test_list_documents_passes_filters(documents: DocumentsClient, load_fixture) -> None:
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("document_minimal.json")]}
+async def test_list_documents_passes_filters(
+    documents: DocumentsClient, load_fixture
+) -> None:
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("document_minimal.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
-        result = await documents.list(page=2, page_size=50, tags=[1, 2], correspondent=7, document_type=3)
+        route = mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
+        result = await documents.list(
+            page=2, page_size=50, tags=[1, 2], correspondent=7, document_type=3
+        )
     params = dict(route.calls.last.request.url.params)
     assert params["page"] == "2"
     assert params["page_size"] == "50"
@@ -30,69 +49,147 @@ async def test_list_documents_passes_filters(documents: DocumentsClient, load_fi
     assert params["document_type__id"] == "3"
     assert result.results[0].id == 1
 
+
 @pytest.mark.asyncio
-async def test_search_uses_query_param(documents: DocumentsClient, load_fixture) -> None:
+async def test_search_uses_query_param(
+    documents: DocumentsClient, load_fixture
+) -> None:
     page = {"count": 0, "next": None, "previous": None, "results": []}
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        route = mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         await documents.search("hello world")
     assert dict(route.calls.last.request.url.params)["query"] == "hello world"
 
+
 @pytest.mark.asyncio
-async def test_search_more_like_uses_more_like_id(documents: DocumentsClient, load_fixture) -> None:
+async def test_search_more_like_uses_more_like_id(
+    documents: DocumentsClient, load_fixture
+) -> None:
     page = {"count": 0, "next": None, "previous": None, "results": []}
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        route = mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         await documents.search("", more_like=42)
     assert dict(route.calls.last.request.url.params)["more_like_id"] == "42"
+
 
 @pytest.mark.asyncio
 async def test_get_document(documents: DocumentsClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/").mock(return_value=httpx.Response(200, json=load_fixture("document_minimal.json")))
+        mock.get("/api/documents/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("document_minimal.json"))
+        )
         doc = await documents.get(1)
     assert doc.id == 1
     assert doc.title == "Test Document"
 
+
 @pytest.mark.asyncio
 async def test_get_content(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/").mock(return_value=httpx.Response(200, json={"id": 1, "title": "x", "content": "OCR content here", "created": "2026-04-23T10:00:00Z", "tags": [], "notes": [], "custom_fields": []}))
+        mock.get("/api/documents/1/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": 1,
+                    "title": "x",
+                    "content": "OCR content here",
+                    "created": "2026-04-23T10:00:00Z",
+                    "tags": [],
+                    "notes": [],
+                    "custom_fields": [],
+                },
+            )
+        )
         content = await documents.get_content(1)
     assert content == "OCR content here"
+
 
 @pytest.mark.asyncio
 async def test_get_thumbnail_returns_bytes(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/thumb/").mock(return_value=httpx.Response(200, content=b"\x89PNGfakebytes", headers={"content-type": "image/png"}))
+        mock.get("/api/documents/1/thumb/").mock(
+            return_value=httpx.Response(
+                200, content=b"\x89PNGfakebytes", headers={"content-type": "image/png"}
+            )
+        )
         data, content_type = await documents.get_thumbnail(1)
     assert data.startswith(b"\x89PNG")
     assert content_type == "image/png"
 
+
 @pytest.mark.asyncio
 async def test_get_metadata(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/metadata/").mock(return_value=httpx.Response(200, json={"original_checksum": "abc", "original_size": 12345, "original_mime_type": "application/pdf"}))
+        mock.get("/api/documents/1/metadata/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "original_checksum": "abc",
+                    "original_size": 12345,
+                    "original_mime_type": "application/pdf",
+                },
+            )
+        )
         meta = await documents.get_metadata(1)
     assert meta.original_checksum == "abc"
+
 
 @pytest.mark.asyncio
 async def test_get_notes(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/notes/").mock(return_value=httpx.Response(200, json=[{"id": 1, "note": "hi", "created": "2026-04-23T10:00:00Z", "user": 1}]))
+        mock.get("/api/documents/1/notes/").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 1,
+                        "note": "hi",
+                        "created": "2026-04-23T10:00:00Z",
+                        "user": 1,
+                    }
+                ],
+            )
+        )
         notes = await documents.get_notes(1)
     assert notes[0].note == "hi"
+
 
 @pytest.mark.asyncio
 async def test_get_history(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/history/").mock(return_value=httpx.Response(200, json=[{"timestamp": "2026-04-23T10:00:00Z", "action": "modify", "actor": "peter"}]))
+        mock.get("/api/documents/1/history/").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "timestamp": "2026-04-23T10:00:00Z",
+                        "action": "modify",
+                        "actor": "peter",
+                    }
+                ],
+            )
+        )
         hist = await documents.get_history(1)
     assert hist[0].action == "modify"
+
 
 @pytest.mark.asyncio
 async def test_get_suggestions(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/documents/1/suggestions/").mock(return_value=httpx.Response(200, json={"correspondents": [7], "tags": [], "document_types": [], "dates": []}))
+        mock.get("/api/documents/1/suggestions/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "correspondents": [7],
+                    "tags": [],
+                    "document_types": [],
+                    "dates": [],
+                },
+            )
+        )
         s = await documents.get_suggestions(1)
     assert s.correspondents == [7]

--- a/tests/unit/client/test_documents_write.py
+++ b/tests/unit/client/test_documents_write.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -40,8 +42,6 @@ async def test_update_sends_only_set_fields(
     assert doc.title == "Renamed"
     # only set fields should be in the payload
     payload = route.calls.last.request.content
-    import json
-
     assert json.loads(payload) == {"title": "Renamed"}
 
 
@@ -86,8 +86,6 @@ async def test_bulk_edit(documents: DocumentsClient) -> None:
             parameters={"tag": 5},
         )
     assert result.result == "OK"
-    import json
-
     body = json.loads(route.calls.last.request.content)
     assert body == {
         "documents": [1, 2, 3],
@@ -98,15 +96,16 @@ async def test_bulk_edit(documents: DocumentsClient) -> None:
 
 @pytest.mark.asyncio
 async def test_add_note(documents: DocumentsClient) -> None:
-    returned = {"id": 9, "note": "new", "created": "2026-04-23T10:00:00Z", "user": 1}
+    existing = {"id": 1, "note": "old", "created": "2026-04-01T10:00:00Z", "user": 1}
+    newest = {"id": 9, "note": "new", "created": "2026-04-23T10:00:00Z", "user": 1}
     async with respx.mock(base_url="http://paperless.test") as mock:
         route = mock.post("/api/documents/1/notes/").mock(
-            return_value=httpx.Response(200, json=[returned])
+            return_value=httpx.Response(200, json=[existing, newest])
         )
         note = await documents.add_note(1, "new")
+    # add_note returns the last item in the list (newest note, not the first)
+    assert note.id == 9
     assert note.note == "new"
-    import json
-
     body = json.loads(route.calls.last.request.content)
     assert body == {"note": "new"}
 

--- a/tests/unit/client/test_documents_write.py
+++ b/tests/unit/client/test_documents_write.py
@@ -1,0 +1,118 @@
+"""Tests for DocumentsClient write operations."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.documents import DocumentsClient
+from paperless_mcp.models.common import BulkEditOperation
+from paperless_mcp.models.document import DocumentPatch
+
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def documents(http: PaperlessHTTP) -> DocumentsClient:
+    return DocumentsClient(http)
+
+
+@pytest.mark.asyncio
+async def test_update_sends_only_set_fields(
+    documents: DocumentsClient, load_fixture
+) -> None:
+    updated = load_fixture("document_minimal.json")
+    updated["title"] = "Renamed"
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.patch("/api/documents/1/").mock(
+            return_value=httpx.Response(200, json=updated)
+        )
+        doc = await documents.update(1, DocumentPatch(title="Renamed"))
+    assert doc.title == "Renamed"
+    # only set fields should be in the payload
+    payload = route.calls.last.request.content
+    import json
+    assert json.loads(payload) == {"title": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_delete(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/documents/1/").mock(
+            return_value=httpx.Response(204)
+        )
+        await documents.delete(1)
+    assert route.called
+
+
+@pytest.mark.asyncio
+async def test_upload_sends_multipart(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/documents/post_document/").mock(
+            return_value=httpx.Response(200, json="abc-task-uuid")
+        )
+        ack = await documents.upload(
+            filename="invoice.pdf",
+            content=b"%PDF-1.4\n...",
+            title="Invoice",
+            tags=[1, 2],
+            correspondent=7,
+        )
+    assert ack.task_id == "abc-task-uuid"
+    request = route.calls.last.request
+    assert b'filename="invoice.pdf"' in request.content
+    # multipart boundary should carry extra fields
+    assert b'name="title"' in request.content
+    assert b'name="tags"' in request.content
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/documents/bulk_edit/").mock(
+            return_value=httpx.Response(200, json={"result": "OK"})
+        )
+        result = await documents.bulk_edit(
+            document_ids=[1, 2, 3],
+            method=BulkEditOperation.ADD_TAG,
+            parameters={"tag": 5},
+        )
+    assert result.result == "OK"
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body == {
+        "documents": [1, 2, 3],
+        "method": "add_tag",
+        "parameters": {"tag": 5},
+    }
+
+
+@pytest.mark.asyncio
+async def test_add_note(documents: DocumentsClient) -> None:
+    returned = {"id": 9, "note": "new", "created": "2026-04-23T10:00:00Z", "user": 1}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/documents/1/notes/").mock(
+            return_value=httpx.Response(200, json=[returned])
+        )
+        note = await documents.add_note(1, "new")
+    assert note.note == "new"
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"note": "new"}
+
+
+@pytest.mark.asyncio
+async def test_delete_note(documents: DocumentsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/documents/1/notes/").mock(
+            return_value=httpx.Response(204)
+        )
+        await documents.delete_note(1, 9)
+    assert "id=9" in str(route.calls.last.request.url)

--- a/tests/unit/client/test_documents_write.py
+++ b/tests/unit/client/test_documents_write.py
@@ -14,7 +14,9 @@ from paperless_mcp.models.document import DocumentPatch
 
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
 
@@ -39,15 +41,14 @@ async def test_update_sends_only_set_fields(
     # only set fields should be in the payload
     payload = route.calls.last.request.content
     import json
+
     assert json.loads(payload) == {"title": "Renamed"}
 
 
 @pytest.mark.asyncio
 async def test_delete(documents: DocumentsClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.delete("/api/documents/1/").mock(
-            return_value=httpx.Response(204)
-        )
+        route = mock.delete("/api/documents/1/").mock(return_value=httpx.Response(204))
         await documents.delete(1)
     assert route.called
 
@@ -86,6 +87,7 @@ async def test_bulk_edit(documents: DocumentsClient) -> None:
         )
     assert result.result == "OK"
     import json
+
     body = json.loads(route.calls.last.request.content)
     assert body == {
         "documents": [1, 2, 3],
@@ -104,6 +106,7 @@ async def test_add_note(documents: DocumentsClient) -> None:
         note = await documents.add_note(1, "new")
     assert note.note == "new"
     import json
+
     body = json.loads(route.calls.last.request.content)
     assert body == {"note": "new"}
 

--- a/tests/unit/client/test_facade.py
+++ b/tests/unit/client/test_facade.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import pytest
+from paperless_mcp.client import PaperlessClient
+
+@pytest.mark.asyncio
+async def test_facade_exposes_sub_clients() -> None:
+    client = PaperlessClient(base_url="http://paperless.test", api_token="t", max_retries=0)
+    try:
+        assert client.documents is not None
+        assert client.tags is not None
+        assert client.correspondents is not None
+        assert client.document_types is not None
+        assert client.custom_fields is not None
+        assert client.storage_paths is not None
+        assert client.saved_views is not None
+        assert client.share_links is not None
+        assert client.tasks is not None
+        assert client.system is not None
+    finally:
+        await client.aclose()
+
+@pytest.mark.asyncio
+async def test_facade_is_async_context_manager() -> None:
+    async with PaperlessClient(base_url="http://paperless.test", api_token="t", max_retries=0) as client:
+        assert client.documents is not None

--- a/tests/unit/client/test_facade.py
+++ b/tests/unit/client/test_facade.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
+
 import pytest
+
 from paperless_mcp.client import PaperlessClient
+
 
 @pytest.mark.asyncio
 async def test_facade_exposes_sub_clients() -> None:
-    client = PaperlessClient(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessClient(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     try:
         assert client.documents is not None
         assert client.tags is not None
@@ -19,7 +24,10 @@ async def test_facade_exposes_sub_clients() -> None:
     finally:
         await client.aclose()
 
+
 @pytest.mark.asyncio
 async def test_facade_is_async_context_manager() -> None:
-    async with PaperlessClient(base_url="http://paperless.test", api_token="t", max_retries=0) as client:
+    async with PaperlessClient(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    ) as client:
         assert client.documents is not None

--- a/tests/unit/client/test_readonly_resources.py
+++ b/tests/unit/client/test_readonly_resources.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.saved_views import SavedViewsClient
+from paperless_mcp.client.share_links import ShareLinksClient
+from paperless_mcp.client.storage_paths import StoragePathsClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.mark.asyncio
+async def test_storage_paths_list(http: PaperlessHTTP, load_fixture) -> None:
+    sp = StoragePathsClient(http)
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("storage_path.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/storage_paths/").mock(return_value=httpx.Response(200, json=page))
+        r = await sp.list()
+    assert r.results[0].id == 2
+
+@pytest.mark.asyncio
+async def test_storage_paths_get(http: PaperlessHTTP, load_fixture) -> None:
+    sp = StoragePathsClient(http)
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/storage_paths/2/").mock(return_value=httpx.Response(200, json=load_fixture("storage_path.json")))
+        r = await sp.get(2)
+    assert r.name == "Invoices by Year"
+
+@pytest.mark.asyncio
+async def test_saved_views_list(http: PaperlessHTTP, load_fixture) -> None:
+    sv = SavedViewsClient(http)
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("saved_view.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/saved_views/").mock(return_value=httpx.Response(200, json=page))
+        r = await sv.list()
+    assert r.results[0].name == "Inbox"
+
+@pytest.mark.asyncio
+async def test_saved_views_get(http: PaperlessHTTP, load_fixture) -> None:
+    sv = SavedViewsClient(http)
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/saved_views/1/").mock(return_value=httpx.Response(200, json=load_fixture("saved_view.json")))
+        r = await sv.get(1)
+    assert r.id == 1
+
+@pytest.mark.asyncio
+async def test_share_links_list(http: PaperlessHTTP, load_fixture) -> None:
+    sl = ShareLinksClient(http)
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("share_link.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.get("/api/share_links/").mock(return_value=httpx.Response(200, json=page))
+        r = await sl.list(document_id=42)
+    assert r.results[0].id == 5
+    assert dict(route.calls.last.request.url.params)["document"] == "42"
+
+@pytest.mark.asyncio
+async def test_share_links_get(http: PaperlessHTTP, load_fixture) -> None:
+    sl = ShareLinksClient(http)
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/share_links/5/").mock(return_value=httpx.Response(200, json=load_fixture("share_link.json")))
+        r = await sl.get(5)
+    assert r.id == 5

--- a/tests/unit/client/test_readonly_resources.py
+++ b/tests/unit/client/test_readonly_resources.py
@@ -1,64 +1,102 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.saved_views import SavedViewsClient
 from paperless_mcp.client.share_links import ShareLinksClient
 from paperless_mcp.client.storage_paths import StoragePathsClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.mark.asyncio
 async def test_storage_paths_list(http: PaperlessHTTP, load_fixture) -> None:
     sp = StoragePathsClient(http)
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("storage_path.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("storage_path.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/storage_paths/").mock(return_value=httpx.Response(200, json=page))
+        mock.get("/api/storage_paths/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         r = await sp.list()
     assert r.results[0].id == 2
+
 
 @pytest.mark.asyncio
 async def test_storage_paths_get(http: PaperlessHTTP, load_fixture) -> None:
     sp = StoragePathsClient(http)
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/storage_paths/2/").mock(return_value=httpx.Response(200, json=load_fixture("storage_path.json")))
+        mock.get("/api/storage_paths/2/").mock(
+            return_value=httpx.Response(200, json=load_fixture("storage_path.json"))
+        )
         r = await sp.get(2)
     assert r.name == "Invoices by Year"
+
 
 @pytest.mark.asyncio
 async def test_saved_views_list(http: PaperlessHTTP, load_fixture) -> None:
     sv = SavedViewsClient(http)
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("saved_view.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("saved_view.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
         mock.get("/api/saved_views/").mock(return_value=httpx.Response(200, json=page))
         r = await sv.list()
     assert r.results[0].name == "Inbox"
 
+
 @pytest.mark.asyncio
 async def test_saved_views_get(http: PaperlessHTTP, load_fixture) -> None:
     sv = SavedViewsClient(http)
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/saved_views/1/").mock(return_value=httpx.Response(200, json=load_fixture("saved_view.json")))
+        mock.get("/api/saved_views/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("saved_view.json"))
+        )
         r = await sv.get(1)
     assert r.id == 1
+
 
 @pytest.mark.asyncio
 async def test_share_links_list(http: PaperlessHTTP, load_fixture) -> None:
     sl = ShareLinksClient(http)
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("share_link.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("share_link.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.get("/api/share_links/").mock(return_value=httpx.Response(200, json=page))
+        route = mock.get("/api/share_links/").mock(
+            return_value=httpx.Response(200, json=page)
+        )
         r = await sl.list(document_id=42)
     assert r.results[0].id == 5
     assert dict(route.calls.last.request.url.params)["document"] == "42"
+
 
 @pytest.mark.asyncio
 async def test_share_links_get(http: PaperlessHTTP, load_fixture) -> None:
     sl = ShareLinksClient(http)
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/share_links/5/").mock(return_value=httpx.Response(200, json=load_fixture("share_link.json")))
+        mock.get("/api/share_links/5/").mock(
+            return_value=httpx.Response(200, json=load_fixture("share_link.json"))
+        )
         r = await sl.get(5)
     assert r.id == 5

--- a/tests/unit/client/test_system.py
+++ b/tests/unit/client/test_system.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.system import SystemClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.mark.asyncio
+async def test_statistics(http: PaperlessHTTP, load_fixture) -> None:
+    system = SystemClient(http)
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/statistics/").mock(return_value=httpx.Response(200, json=load_fixture("statistics.json")))
+        s = await system.statistics()
+    assert s.documents_total == 1234
+
+@pytest.mark.asyncio
+async def test_remote_version(http: PaperlessHTTP, load_fixture) -> None:
+    system = SystemClient(http)
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/remote_version/").mock(return_value=httpx.Response(200, json=load_fixture("remote_version.json")))
+        v = await system.remote_version()
+    assert v.version == "2.7.2"

--- a/tests/unit/client/test_system.py
+++ b/tests/unit/client/test_system.py
@@ -1,26 +1,39 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.system import SystemClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.mark.asyncio
 async def test_statistics(http: PaperlessHTTP, load_fixture) -> None:
     system = SystemClient(http)
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/statistics/").mock(return_value=httpx.Response(200, json=load_fixture("statistics.json")))
+        mock.get("/api/statistics/").mock(
+            return_value=httpx.Response(200, json=load_fixture("statistics.json"))
+        )
         s = await system.statistics()
     assert s.documents_total == 1234
+
 
 @pytest.mark.asyncio
 async def test_remote_version(http: PaperlessHTTP, load_fixture) -> None:
     system = SystemClient(http)
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/remote_version/").mock(return_value=httpx.Response(200, json=load_fixture("remote_version.json")))
+        mock.get("/api/remote_version/").mock(
+            return_value=httpx.Response(200, json=load_fixture("remote_version.json"))
+        )
         v = await system.remote_version()
     assert v.version == "2.7.2"

--- a/tests/unit/client/test_tags.py
+++ b/tests/unit/client/test_tags.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.tags import TagsClient
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def tags(http: PaperlessHTTP) -> TagsClient:
+    return TagsClient(http)
+
+@pytest.mark.asyncio
+async def test_list(tags: TagsClient, load_fixture) -> None:
+    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("tag.json")]}
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.get("/api/tags/").mock(return_value=httpx.Response(200, json=page))
+        result = await tags.list(page=1, page_size=100, name__icontains="inv")
+    params = dict(route.calls.last.request.url.params)
+    assert params["name__icontains"] == "inv"
+    assert result.results[0].name == "Invoice"
+
+@pytest.mark.asyncio
+async def test_get(tags: TagsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tags/1/").mock(return_value=httpx.Response(200, json=load_fixture("tag.json")))
+        tag = await tags.get(1)
+    assert tag.id == 1

--- a/tests/unit/client/test_tags.py
+++ b/tests/unit/client/test_tags.py
@@ -1,21 +1,35 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.tags import TagsClient
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def tags(http: PaperlessHTTP) -> TagsClient:
     return TagsClient(http)
 
+
 @pytest.mark.asyncio
 async def test_list(tags: TagsClient, load_fixture) -> None:
-    page = {"count": 1, "next": None, "previous": None, "results": [load_fixture("tag.json")]}
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("tag.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
         route = mock.get("/api/tags/").mock(return_value=httpx.Response(200, json=page))
         result = await tags.list(page=1, page_size=100, name__icontains="inv")
@@ -23,9 +37,12 @@ async def test_list(tags: TagsClient, load_fixture) -> None:
     assert params["name__icontains"] == "inv"
     assert result.results[0].name == "Invoice"
 
+
 @pytest.mark.asyncio
 async def test_get(tags: TagsClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tags/1/").mock(return_value=httpx.Response(200, json=load_fixture("tag.json")))
+        mock.get("/api/tags/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("tag.json"))
+        )
         tag = await tags.get(1)
     assert tag.id == 1

--- a/tests/unit/client/test_tags_write.py
+++ b/tests/unit/client/test_tags_write.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.tags import TagsClient
+from paperless_mcp.models.tag import TagCreate, TagPatch
+
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def tags(http: PaperlessHTTP) -> TagsClient:
+    return TagsClient(http)
+
+
+@pytest.mark.asyncio
+async def test_create(tags: TagsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/tags/").mock(
+            return_value=httpx.Response(201, json=load_fixture("tag.json"))
+        )
+        result = await tags.create(TagCreate(name="New"))
+    assert result.id == 1
+
+
+@pytest.mark.asyncio
+async def test_update(tags: TagsClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.patch("/api/tags/1/").mock(
+            return_value=httpx.Response(200, json=load_fixture("tag.json"))
+        )
+        result = await tags.update(1, TagPatch(name="Renamed"))
+    assert result.id == 1
+    import json
+    assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_delete(tags: TagsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.delete("/api/tags/1/").mock(return_value=httpx.Response(204))
+        await tags.delete(1)
+    assert route.called
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit(tags: TagsClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        route = mock.post("/api/bulk_edit_objects/").mock(
+            return_value=httpx.Response(200, json={"result": "OK"})
+        )
+        result = await tags.bulk_edit(
+            operation="set_permissions", ids=[1, 2], parameters={}
+        )
+    assert result.result == "OK"
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body["object_type"] == "tags"
+    assert body["objects"] == [1, 2]
+    assert body["operation"] == "set_permissions"

--- a/tests/unit/client/test_tags_write.py
+++ b/tests/unit/client/test_tags_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -41,8 +43,6 @@ async def test_update(tags: TagsClient, load_fixture) -> None:
         )
         result = await tags.update(1, TagPatch(name="Renamed"))
     assert result.id == 1
-    import json
-
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
@@ -64,8 +64,6 @@ async def test_bulk_edit(tags: TagsClient) -> None:
             operation="set_permissions", ids=[1, 2], parameters={}
         )
     assert result.result == "OK"
-    import json
-
     body = json.loads(route.calls.last.request.content)
     assert body["object_type"] == "tags"
     assert body["objects"] == [1, 2]

--- a/tests/unit/client/test_tags_write.py
+++ b/tests/unit/client/test_tags_write.py
@@ -11,7 +11,9 @@ from paperless_mcp.models.tag import TagCreate, TagPatch
 
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
 
@@ -24,7 +26,7 @@ def tags(http: PaperlessHTTP) -> TagsClient:
 @pytest.mark.asyncio
 async def test_create(tags: TagsClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.post("/api/tags/").mock(
+        mock.post("/api/tags/").mock(
             return_value=httpx.Response(201, json=load_fixture("tag.json"))
         )
         result = await tags.create(TagCreate(name="New"))
@@ -40,6 +42,7 @@ async def test_update(tags: TagsClient, load_fixture) -> None:
         result = await tags.update(1, TagPatch(name="Renamed"))
     assert result.id == 1
     import json
+
     assert json.loads(route.calls.last.request.content) == {"name": "Renamed"}
 
 
@@ -62,6 +65,7 @@ async def test_bulk_edit(tags: TagsClient) -> None:
         )
     assert result.result == "OK"
     import json
+
     body = json.loads(route.calls.last.request.content)
     assert body["object_type"] == "tags"
     assert body["objects"] == [1, 2]

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -36,20 +36,22 @@ async def test_list_all(tasks: TasksClient, load_fixture) -> None:
 @pytest.mark.asyncio
 async def test_get_by_uuid_uses_list_filter(tasks: TasksClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(
+        route = mock.get("/api/tasks/").mock(
             return_value=httpx.Response(200, json=[load_fixture("task_success.json")])
         )
         task = await tasks.get("abc-123-success")
     assert task is not None
     assert task.status is TaskStatus.SUCCESS
+    assert route.calls.last.request.url.params.get("task_id") == "abc-123-success"
 
 
 @pytest.mark.asyncio
 async def test_get_unknown_returns_none(tasks: TasksClient) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[]))
+        route = mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[]))
         task = await tasks.get("nope")
     assert task is None
+    assert route.calls.last.request.url.params.get("task_id") == "nope"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import httpx, pytest, respx
+from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.client.tasks import TasksClient
+from paperless_mcp.models.task import TaskStatus
+
+@pytest.fixture
+async def http():
+    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    yield client
+    await client.aclose()
+
+@pytest.fixture
+def tasks(http: PaperlessHTTP) -> TasksClient:
+    return TasksClient(http)
+
+@pytest.mark.asyncio
+async def test_list_all(tasks: TasksClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[load_fixture("task_pending.json")]))
+        result = await tasks.list()
+    assert result[0].status is TaskStatus.PENDING
+
+@pytest.mark.asyncio
+async def test_get_by_uuid_uses_list_filter(tasks: TasksClient, load_fixture) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[load_fixture("task_success.json")]))
+        task = await tasks.get("abc-123-success")
+    assert task is not None
+    assert task.status is TaskStatus.SUCCESS
+
+@pytest.mark.asyncio
+async def test_get_unknown_returns_none(tasks: TasksClient) -> None:
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[]))
+        task = await tasks.get("nope")
+    assert task is None
+
+@pytest.mark.asyncio
+async def test_wait_for_resolves_success(tasks: TasksClient, load_fixture) -> None:
+    pending = load_fixture("task_pending.json")
+    success = load_fixture("task_success.json")
+    success["task_id"] = pending["task_id"]
+    responses = [httpx.Response(200, json=[pending]), httpx.Response(200, json=[pending]), httpx.Response(200, json=[success])]
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tasks/").mock(side_effect=responses)
+        task = await tasks.wait_for(pending["task_id"], timeout_seconds=2, poll_seconds=0.01)
+    assert task.status is TaskStatus.SUCCESS
+
+@pytest.mark.asyncio
+async def test_wait_for_times_out(tasks: TasksClient, load_fixture) -> None:
+    pending = load_fixture("task_pending.json")
+    async with respx.mock(base_url="http://paperless.test") as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[pending]))
+        with pytest.raises(TimeoutError):
+            await tasks.wait_for(pending["task_id"], timeout_seconds=0.05, poll_seconds=0.01)

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -1,33 +1,48 @@
 from __future__ import annotations
-import httpx, pytest, respx
+
+import httpx
+import pytest
+import respx
+
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.tasks import TasksClient
 from paperless_mcp.models.task import TaskStatus
 
+
 @pytest.fixture
 async def http():
-    client = PaperlessHTTP(base_url="http://paperless.test", api_token="t", max_retries=0)
+    client = PaperlessHTTP(
+        base_url="http://paperless.test", api_token="t", max_retries=0
+    )
     yield client
     await client.aclose()
+
 
 @pytest.fixture
 def tasks(http: PaperlessHTTP) -> TasksClient:
     return TasksClient(http)
 
+
 @pytest.mark.asyncio
 async def test_list_all(tasks: TasksClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[load_fixture("task_pending.json")]))
+        mock.get("/api/tasks/").mock(
+            return_value=httpx.Response(200, json=[load_fixture("task_pending.json")])
+        )
         result = await tasks.list()
     assert result[0].status is TaskStatus.PENDING
+
 
 @pytest.mark.asyncio
 async def test_get_by_uuid_uses_list_filter(tasks: TasksClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[load_fixture("task_success.json")]))
+        mock.get("/api/tasks/").mock(
+            return_value=httpx.Response(200, json=[load_fixture("task_success.json")])
+        )
         task = await tasks.get("abc-123-success")
     assert task is not None
     assert task.status is TaskStatus.SUCCESS
+
 
 @pytest.mark.asyncio
 async def test_get_unknown_returns_none(tasks: TasksClient) -> None:
@@ -36,16 +51,24 @@ async def test_get_unknown_returns_none(tasks: TasksClient) -> None:
         task = await tasks.get("nope")
     assert task is None
 
+
 @pytest.mark.asyncio
 async def test_wait_for_resolves_success(tasks: TasksClient, load_fixture) -> None:
     pending = load_fixture("task_pending.json")
     success = load_fixture("task_success.json")
     success["task_id"] = pending["task_id"]
-    responses = [httpx.Response(200, json=[pending]), httpx.Response(200, json=[pending]), httpx.Response(200, json=[success])]
+    responses = [
+        httpx.Response(200, json=[pending]),
+        httpx.Response(200, json=[pending]),
+        httpx.Response(200, json=[success]),
+    ]
     async with respx.mock(base_url="http://paperless.test") as mock:
         mock.get("/api/tasks/").mock(side_effect=responses)
-        task = await tasks.wait_for(pending["task_id"], timeout_seconds=2, poll_seconds=0.01)
+        task = await tasks.wait_for(
+            pending["task_id"], timeout_seconds=2, poll_seconds=0.01
+        )
     assert task.status is TaskStatus.SUCCESS
+
 
 @pytest.mark.asyncio
 async def test_wait_for_times_out(tasks: TasksClient, load_fixture) -> None:
@@ -53,4 +76,6 @@ async def test_wait_for_times_out(tasks: TasksClient, load_fixture) -> None:
     async with respx.mock(base_url="http://paperless.test") as mock:
         mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=[pending]))
         with pytest.raises(TimeoutError):
-            await tasks.wait_for(pending["task_id"], timeout_seconds=0.05, poll_seconds=0.01)
+            await tasks.wait_for(
+                pending["task_id"], timeout_seconds=0.05, poll_seconds=0.01
+            )


### PR DESCRIPTION
## Summary

- **Phase E**: Ten typed async sub-clients wrapping the Paperless REST API (read methods): `DocumentsClient`, `TagsClient`, `CorrespondentsClient`, `DocumentTypesClient`, `CustomFieldsClient`, `StoragePathsClient`, `SavedViewsClient`, `ShareLinksClient`, `TasksClient` (with `wait_for()` polling), `SystemClient`; `PaperlessClient` facade composing all ten
- **Phase F**: Write methods on each CRUD client (`create`, `update`, `delete`, `bulk_edit`); `DocumentsClient` adds `upload()` (multipart), `add_note()`, `delete_note()`, `get_content()`, `get_thumbnail()`, `get_preview()`, `download()`

All clients use `builtins.list` / `collections.abc.Sequence` annotations to avoid mypy's `valid-type` false-positive caused by the `list` method shadowing the built-in.

## Test plan
- [ ] `uv run pytest tests/unit/client/` — HTTP client tests pass (respx-mocked)
- [ ] `uv run mypy src/paperless_mcp/` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)