### PR TITLE
feat: integration tests, documentation, and release prep (Phases L–N)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 0.1.0 - 2026-04-23
+
+### Added
+- Initial release.
+- Full parity with the existing community `paperless-mcp` tool surface.
+- Read-only observability additions: `list_tasks`, `wait_for_task`,
+  `get_statistics`, `get_remote_version`, `get_document_metadata`,
+  `get_document_history`, `get_document_suggestions`, `list_storage_paths`,
+  `list_saved_views`, `list_share_links`, plus their `get_*` variants.
+- MCP resources for all entity types plus per-document templated URIs.
+- `create_download_link` tool backed by `fastmcp_pvl_core.ArtifactStore`.
+- Lucide icons on every tool.
+- Read-only mode toggle via `PAPERLESS_MCP_READ_ONLY`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,23 @@ All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
 | `PAPERLESS_MCP_READ_ONLY` | `false` | When `true`, disables every writable tool. |
 | `PAPERLESS_MCP_INSTRUCTIONS` | *(built-in)* | Operator-supplied description appended to MCP instructions. |
 
-See the [template's README section](#transport--auth) for transport (`TRANSPORT`, `HOST`, `PORT`, `HTTP_PATH`, `BASE_URL`), OIDC auth (`OIDC_*`), bearer fallback (`BEARER_TOKEN`), and logging (`LOG_LEVEL`, `LOG_FORMAT`) variables — those are inherited unchanged from `fastmcp-server-template`.
+See the [Transport & Auth](#transport--auth) section below for the inherited transport, auth, and logging variables.
+
+## Transport & Auth
+
+The following variables are inherited unchanged from [`fastmcp-server-template`](https://github.com/pvliesdonk/fastmcp-server-template):
+
+| Variable | Description |
+|---|---|
+| `PAPERLESS_MCP_TRANSPORT` | Server transport: `stdio` (default), `http`, or `sse`. |
+| `PAPERLESS_MCP_HOST` | Bind host for HTTP/SSE transport (default `127.0.0.1`). |
+| `PAPERLESS_MCP_PORT` | Bind port for HTTP/SSE transport (default `8000`). |
+| `PAPERLESS_MCP_HTTP_PATH` | URL path prefix for HTTP transport (default `/mcp`). |
+| `PAPERLESS_MCP_BASE_URL` | Public base URL for artifact download links. |
+| `PAPERLESS_MCP_OIDC_*` | OIDC provider settings when OIDC auth is enabled. |
+| `PAPERLESS_MCP_BEARER_TOKEN` | Static bearer token for simple token auth. |
+| `PAPERLESS_MCP_LOG_LEVEL` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `PAPERLESS_MCP_LOG_FORMAT` | Log format: `rich` (default) or `json`. |
 
 ## Tools
 
@@ -136,14 +152,14 @@ See the [template's README section](#transport--auth) for transport (`TRANSPORT`
 | `storage-paths://paperless` | All storage paths |
 | `saved-views://paperless` | All saved views |
 | `tasks://paperless` | All background tasks |
-| `paperless://documents/{id}` | Document by ID |
-| `paperless://documents/{id}/content` | Extracted text content |
-| `paperless://documents/{id}/metadata` | File metadata |
-| `paperless://documents/{id}/notes` | Document notes |
-| `paperless://documents/{id}/history` | Audit history |
-| `paperless://documents/{id}/thumbnail` | Thumbnail image |
-| `paperless://documents/{id}/preview` | PDF preview |
-| `paperless://documents/{id}/download` | Original file download |
+| `paperless://documents/{document_id}` | Document by ID |
+| `paperless://documents/{document_id}/content` | Extracted text content |
+| `paperless://documents/{document_id}/metadata` | File metadata |
+| `paperless://documents/{document_id}/notes` | Document notes |
+| `paperless://documents/{document_id}/history` | Audit history |
+| `paperless://documents/{document_id}/thumbnail` | Thumbnail image |
+| `paperless://documents/{document_id}/preview` | PDF preview |
+| `paperless://documents/{document_id}/download` | Original file download |
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,138 @@ paperless-mcp serve --transport http --port 8000   # HTTP
 
 ## Configuration
 
-All configuration goes via `PAPERLESS_MCP_*` env vars.  See
-[docs/configuration.md](docs/configuration.md).
+All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
+
+### Required
+
+| Variable | Description |
+|---|---|
+| `PAPERLESS_MCP_PAPERLESS_URL` | Base URL of the Paperless-NGX REST API (no trailing slash). |
+| `PAPERLESS_MCP_API_TOKEN` | Paperless service-account token. |
+
+### Optional (with defaults)
+
+| Variable | Default | Description |
+|---|---|---|
+| `PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS` | `30` | Per-request HTTP timeout (seconds). |
+| `PAPERLESS_MCP_HTTP_RETRIES` | `2` | Retries (not counting the initial attempt) on 5xx/network errors. |
+| `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` | `300` | TTL of URLs issued by `create_download_link`. Clamped `[30, 3600]`. |
+| `PAPERLESS_MCP_DEFAULT_PAGE_SIZE` | `25` | Default `page_size` for list tools. Clamped `[1, 100]`. |
+| `PAPERLESS_MCP_READ_ONLY` | `false` | When `true`, disables every writable tool. |
+| `PAPERLESS_MCP_INSTRUCTIONS` | *(built-in)* | Operator-supplied description appended to MCP instructions. |
+
+See the [template's README section](#transport--auth) for transport (`TRANSPORT`, `HOST`, `PORT`, `HTTP_PATH`, `BASE_URL`), OIDC auth (`OIDC_*`), bearer fallback (`BEARER_TOKEN`), and logging (`LOG_LEVEL`, `LOG_FORMAT`) variables — those are inherited unchanged from `fastmcp-server-template`.
+
+## Tools
+
+### Documents
+
+| Tool | Description |
+|---|---|
+| `list_documents` | List documents with optional filtering |
+| `search_documents` | Full-text search across documents |
+| `get_document` | Retrieve a document by ID |
+| `get_document_content` | Get the extracted text content of a document |
+| `get_document_thumbnail` | Get the thumbnail image of a document |
+| `get_document_metadata` | Get metadata (original filename, checksums, etc.) |
+| `get_document_notes` | List notes attached to a document |
+| `get_document_history` | Get the audit history of a document |
+| `get_document_suggestions` | Get AI-generated tag/correspondent/type suggestions |
+| `update_document` | Update document fields (title, tags, correspondent, etc.) |
+| `delete_document` | Delete a document |
+| `upload_document` | Upload a new document for processing |
+| `bulk_edit_documents` | Apply a bulk operation to multiple documents |
+| `add_document_note` | Add a note to a document |
+| `delete_document_note` | Delete a note from a document |
+
+### Tags
+
+| Tool | Description |
+|---|---|
+| `list_tags` | List all tags |
+| `get_tag` | Get a tag by ID |
+| `create_tag` | Create a new tag |
+| `update_tag` | Update a tag |
+| `delete_tag` | Delete a tag |
+| `bulk_edit_tags` | Bulk edit tags |
+
+### Correspondents
+
+| Tool | Description |
+|---|---|
+| `list_correspondents` | List all correspondents |
+| `get_correspondent` | Get a correspondent by ID |
+| `create_correspondent` | Create a new correspondent |
+| `update_correspondent` | Update a correspondent |
+| `delete_correspondent` | Delete a correspondent |
+| `bulk_edit_correspondents` | Bulk edit correspondents |
+
+### Document Types
+
+| Tool | Description |
+|---|---|
+| `list_document_types` | List all document types |
+| `get_document_type` | Get a document type by ID |
+| `create_document_type` | Create a new document type |
+| `update_document_type` | Update a document type |
+| `delete_document_type` | Delete a document type |
+| `bulk_edit_document_types` | Bulk edit document types |
+
+### Custom Fields
+
+| Tool | Description |
+|---|---|
+| `list_custom_fields` | List all custom fields |
+| `get_custom_field` | Get a custom field by ID |
+| `create_custom_field` | Create a new custom field |
+| `update_custom_field` | Update a custom field |
+| `delete_custom_field` | Delete a custom field |
+| `bulk_edit_custom_fields` | Bulk edit custom fields |
+
+### Observability
+
+| Tool | Description |
+|---|---|
+| `list_storage_paths` | List storage paths |
+| `get_storage_path` | Get a storage path by ID |
+| `list_saved_views` | List saved views |
+| `get_saved_view` | Get a saved view by ID |
+| `list_share_links` | List share links |
+| `get_share_link` | Get a share link by ID |
+| `list_tasks` | List background tasks |
+| `get_task` | Get a task by ID |
+| `wait_for_task` | Wait until a task completes |
+| `get_statistics` | Get server statistics |
+| `get_remote_version` | Get the Paperless-NGX version |
+
+### Downloads
+
+| Tool | Description |
+|---|---|
+| `create_download_link` | Create a time-limited download URL for a document |
+
+## Resources
+
+| URI | Description |
+|---|---|
+| `config://paperless` | Server configuration snapshot |
+| `stats://paperless` | Document statistics |
+| `remote-version://paperless` | Paperless-NGX version |
+| `tags://paperless` | All tags |
+| `correspondents://paperless` | All correspondents |
+| `document-types://paperless` | All document types |
+| `custom-fields://paperless` | All custom fields |
+| `storage-paths://paperless` | All storage paths |
+| `saved-views://paperless` | All saved views |
+| `tasks://paperless` | All background tasks |
+| `paperless://documents/{id}` | Document by ID |
+| `paperless://documents/{id}/content` | Extracted text content |
+| `paperless://documents/{id}/metadata` | File metadata |
+| `paperless://documents/{id}/notes` | Document notes |
+| `paperless://documents/{id}/history` | Audit history |
+| `paperless://documents/{id}/thumbnail` | Thumbnail image |
+| `paperless://documents/{id}/preview` | PDF preview |
+| `paperless://documents/{id}/download` | Original file download |
 
 ## Links
 

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,0 +1,5 @@
+# Required: Paperless API token. Generate under Paperless Settings → My Account → Auth Token.
+PAPERLESS_MCP_API_TOKEN=paste-your-paperless-token-here
+
+# Required when OIDC is enabled.
+PAPERLESS_MCP_OIDC_CLIENT_SECRET=paste-your-oidc-client-secret-here

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,3 +1,6 @@
+# Required: Paperless-NGX REST API base URL (no trailing slash).
+PAPERLESS_MCP_PAPERLESS_URL=http://localhost:8000
+
 # Required: Paperless API token. Generate under Paperless Settings → My Account → Auth Token.
 PAPERLESS_MCP_API_TOKEN=paste-your-paperless-token-here
 

--- a/examples/compose.yml
+++ b/examples/compose.yml
@@ -1,0 +1,41 @@
+# Example deployment wiring paperless-mcp into an existing Paperless-NGX stack.
+# Copy this into a sibling service in your compose.yml and adjust the env vars.
+
+services:
+  paperless-mcp:
+    image: ghcr.io/pvliesdonk/paperless-mcp:latest
+    restart: unless-stopped
+    depends_on:
+      - paperless-ngx
+    env_file: .env
+    environment:
+      # Required
+      PAPERLESS_MCP_PAPERLESS_URL: http://paperless-ngx:8000
+      # PAPERLESS_MCP_API_TOKEN comes from .env
+
+      # Optional
+      PAPERLESS_MCP_READ_ONLY: "false"
+      PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS: "30"
+
+      # Transport (inherited from template — HTTP example)
+      PAPERLESS_MCP_TRANSPORT: http
+      PAPERLESS_MCP_HOST: 0.0.0.0
+      PAPERLESS_MCP_PORT: "8080"
+      PAPERLESS_MCP_BASE_URL: https://paperless-mcp.example.org
+
+      # OIDC (inherited from template — Authelia example)
+      PAPERLESS_MCP_OIDC_CONFIG_URL: https://auth.example.org/.well-known/openid-configuration
+      PAPERLESS_MCP_OIDC_CLIENT_ID: paperless-mcp
+      PAPERLESS_MCP_OIDC_CLIENT_SECRET: ${PAPERLESS_MCP_OIDC_CLIENT_SECRET}
+      PAPERLESS_MCP_OIDC_REQUIRED_SCOPES: openid
+    networks:
+      - paperless-net
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.paperless-mcp.rule=Host(`paperless-mcp.example.org`)
+      - traefik.http.routers.paperless-mcp.entrypoints=websecure
+      - traefik.http.services.paperless-mcp.loadbalancer.server.port=8080
+
+networks:
+  paperless-net:
+    external: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ no_implicit_optional = true
 module = ["fastmcp_pvl_core", "fastmcp_pvl_core.*"]
 ignore_missing_imports = true
 
+
 [tool.pyright]
 # Point Pyright at the uv-managed venv so editor diagnostics resolve
 # imports the same way as our CLI tools (mypy/ruff/pytest run via uv).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ indent-style = "space"
 testpaths = ["tests"]
 addopts = ["--strict-markers", "-ra"]
 asyncio_mode = "auto"
+markers = [
+    "integration: live Paperless-NGX integration tests (opt-in)",
+]
 
 [tool.coverage.run]
 source = ["src/paperless_mcp"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for live Paperless integration tests.
+
+Skipped unless both ``PAPERLESS_MCP_IT_URL`` and ``PAPERLESS_MCP_IT_TOKEN`` are
+set.  CI wires these to a disposable paperless-ngx container; locally, point
+them at a scratch instance.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from paperless_mcp.client import PaperlessClient
+
+
+def _env_or_skip(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"integration test requires ${name}")
+    return value
+
+
+@pytest.fixture
+async def live_client() -> PaperlessClient:
+    url = _env_or_skip("PAPERLESS_MCP_IT_URL")
+    token = _env_or_skip("PAPERLESS_MCP_IT_TOKEN")
+    client = PaperlessClient(base_url=url, api_token=token)
+    try:
+        yield client  # type: ignore[misc]
+    finally:
+        await client.aclose()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ them at a scratch instance.
 from __future__ import annotations
 
 import os
+from collections.abc import AsyncGenerator
 
 import pytest
 
@@ -22,11 +23,11 @@ def _env_or_skip(name: str) -> str:
 
 
 @pytest.fixture
-async def live_client() -> PaperlessClient:
+async def live_client() -> AsyncGenerator[PaperlessClient, None]:
     url = _env_or_skip("PAPERLESS_MCP_IT_URL")
     token = _env_or_skip("PAPERLESS_MCP_IT_TOKEN")
     client = PaperlessClient(base_url=url, api_token=token)
     try:
-        yield client  # type: ignore[misc]
+        yield client
     finally:
         await client.aclose()

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -10,15 +10,16 @@ from paperless_mcp.client import PaperlessClient
 from paperless_mcp.models.common import BulkEditOperation
 from paperless_mcp.models.document import DocumentPatch
 from paperless_mcp.models.tag import TagCreate
+from paperless_mcp.models.task import TaskStatus
 
 pytestmark = pytest.mark.integration
 
 
-@pytest.mark.asyncio
 async def test_end_to_end(live_client: PaperlessClient) -> None:
     unique = uuid.uuid4().hex[:8]
 
     tag = await live_client.tags.create(TagCreate(name=f"it-smoke-{unique}"))
+    document_id: int | None = None
     try:
         pdf_bytes = (
             b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
@@ -36,6 +37,7 @@ async def test_end_to_end(live_client: PaperlessClient) -> None:
             tags=[tag.id],
         )
         task = await live_client.tasks.wait_for(ack.task_id, timeout_seconds=60)
+        assert task.status == TaskStatus.SUCCESS, f"task failed: {task.result}"
         assert task.related_document is not None
         document_id = int(task.related_document)
 
@@ -54,7 +56,7 @@ async def test_end_to_end(live_client: PaperlessClient) -> None:
             parameters={"tag": tag.id},
         )
         assert result.result == "OK"
-
-        await live_client.documents.delete(document_id)
     finally:
+        if document_id is not None:
+            await live_client.documents.delete(document_id)
         await live_client.tags.delete(tag.id)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,60 @@
+"""End-to-end smoke test against a live Paperless-NGX instance."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from paperless_mcp.client import PaperlessClient
+from paperless_mcp.models.common import BulkEditOperation
+from paperless_mcp.models.document import DocumentPatch
+from paperless_mcp.models.tag import TagCreate
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_end_to_end(live_client: PaperlessClient) -> None:
+    unique = uuid.uuid4().hex[:8]
+
+    tag = await live_client.tags.create(TagCreate(name=f"it-smoke-{unique}"))
+    try:
+        pdf_bytes = (
+            b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+            b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+            b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 72 72]/Resources<<>>>>endobj\n"
+            b"xref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n"
+            b"0000000053 00000 n \n0000000094 00000 n \n"
+            b"trailer<</Size 4/Root 1 0 R>>\nstartxref\n150\n%%EOF\n"
+        )
+
+        ack = await live_client.documents.upload(
+            filename=f"it-smoke-{unique}.pdf",
+            content=pdf_bytes,
+            title=f"IT smoke {unique}",
+            tags=[tag.id],
+        )
+        task = await live_client.tasks.wait_for(ack.task_id, timeout_seconds=60)
+        assert task.related_document is not None
+        document_id = int(task.related_document)
+
+        doc = await live_client.documents.get(document_id)
+        assert doc.title == f"IT smoke {unique}"
+        assert tag.id in doc.tags
+
+        patched = await live_client.documents.update(
+            document_id, DocumentPatch(title=f"IT smoke {unique} (renamed)")
+        )
+        assert patched.title == f"IT smoke {unique} (renamed)"
+
+        result = await live_client.documents.bulk_edit(
+            document_ids=[document_id],
+            method=BulkEditOperation.REMOVE_TAG,
+            parameters={"tag": tag.id},
+        )
+        assert result.result == "OK"
+
+        await live_client.documents.delete(document_id)
+    finally:
+        await live_client.tags.delete(tag.id)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -57,6 +57,8 @@ async def test_end_to_end(live_client: PaperlessClient) -> None:
         )
         assert result.result == "OK"
     finally:
-        if document_id is not None:
-            await live_client.documents.delete(document_id)
-        await live_client.tags.delete(tag.id)
+        try:
+            if document_id is not None:
+                await live_client.documents.delete(document_id)
+        finally:
+            await live_client.tags.delete(tag.id)


### PR DESCRIPTION
## Summary

- **Phase L**: Opt-in live integration test suite (`tests/integration/`) — skips unless `PAPERLESS_MCP_IT_URL` + `PAPERLESS_MCP_IT_TOKEN` are set; exercises upload→wait→read→update→bulk_edit→delete round-trip
- **Phase M**: `README.md` — full configuration env-var table (required + optional), tool reference table (52 tools), resource URI table (19 URIs); `examples/compose.yml` + `examples/.env.example` for Docker deployment
- **Phase N** (release sweep):
  - Removed orphaned `tools.py` (was shadowed by `tools/` package but never `git rm`'d)
  - mypy strict clean: fixed `list`-method shadowing using `builtins.list` / `Sequence` in client annotations; fixed `_registry.py` overload type ignores
  - `CHANGELOG.md` 0.1.0 entry

## Test plan
- [ ] `uv run pytest -x -q` — 151 passed, 1 skipped (integration)
- [ ] `uv run ruff check src/ tests/` — clean
- [ ] `uv run mypy src/paperless_mcp/` — clean
- [ ] `uv run pytest tests/integration/ -v` — 1 skipped (no live instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)