### PR TITLE
fix(models): accept nested user/owner objects from newer Paperless-NGX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,8 @@ ignore = ["E501"]
 "src/paperless_mcp/resources/*.py" = ["TC001", "TC002", "TC003"]
 "src/paperless_mcp/prompts.py" = ["B008", "TC002", "ARG001"]
 "tests/**/*.py" = ["TC001", "TC002", "TC003", "ARG001"]
-# Pydantic model files need runtime imports for type resolution — TC002/TC003 are false positives.
-"src/paperless_mcp/models/*.py" = ["TC002", "TC003"]
+# Pydantic model files need runtime imports for type resolution — TC001/TC002/TC003 are false positives.
+"src/paperless_mcp/models/*.py" = ["TC001", "TC002", "TC003"]
 # httpx appears in except clauses (runtime); AsyncIterator used in generator return types.
 "src/paperless_mcp/client/_errors.py" = ["TC002"]
 "src/paperless_mcp/client/_http.py" = ["TC003"]

--- a/src/paperless_mcp/models/_compat.py
+++ b/src/paperless_mcp/models/_compat.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any
 
 from pydantic import BeforeValidator
+
+logger = logging.getLogger(__name__)
 
 
 def _coerce_user_id(value: Any) -> Any:
@@ -15,9 +18,13 @@ def _coerce_user_id(value: Any) -> Any:
     releases returned just ``3``.  We surface only the ID downstream, so
     extract it when we see the dict form.  Returns the input unchanged
     otherwise (covering ``None`` and the bare-int legacy shape).
+
+    If the dict is missing the ``"id"`` key, return the original dict so
+    Pydantic raises a ``ValidationError`` — silently coercing to ``None``
+    would hide upstream schema drift.
     """
     if isinstance(value, dict):
-        return value.get("id")
+        return value.get("id", value)
     return value
 
 
@@ -28,9 +35,13 @@ def _coerce_username(value: Any) -> Any:
     held a username string (e.g. audit-log ``actor``).  Newer Paperless
     returns ``{"id": 3, "username": "alice", ...}``; we extract the
     ``username`` so the field's contract stays a plain string.
+
+    If the dict is missing the ``"username"`` key, return the original
+    dict so Pydantic raises a ``ValidationError`` instead of silently
+    dropping the field.
     """
     if isinstance(value, dict):
-        return value.get("username")
+        return value.get("username", value)
     return value
 
 

--- a/src/paperless_mcp/models/_compat.py
+++ b/src/paperless_mcp/models/_compat.py
@@ -1,0 +1,38 @@
+"""Compatibility helpers for Paperless-NGX schema variations."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+
+
+def _coerce_user_id(value: Any) -> Any:
+    """Collapse a user reference down to its integer ID.
+
+    Newer Paperless-NGX releases return ``user`` / ``owner`` fields as a
+    nested object like ``{"id": 3, "username": "alice", ...}`` where older
+    releases returned just ``3``.  We surface only the ID downstream, so
+    extract it when we see the dict form.  Returns the input unchanged
+    otherwise (covering ``None`` and the bare-int legacy shape).
+    """
+    if isinstance(value, dict):
+        return value.get("id")
+    return value
+
+
+def _coerce_username(value: Any) -> Any:
+    """Collapse a user reference down to its username string.
+
+    Same schema drift as ``_coerce_user_id`` but for fields that historically
+    held a username string (e.g. audit-log ``actor``).  Newer Paperless
+    returns ``{"id": 3, "username": "alice", ...}``; we extract the
+    ``username`` so the field's contract stays a plain string.
+    """
+    if isinstance(value, dict):
+        return value.get("username")
+    return value
+
+
+UserId = Annotated[int | None, BeforeValidator(_coerce_user_id)]
+Username = Annotated[str | None, BeforeValidator(_coerce_username)]

--- a/src/paperless_mcp/models/correspondent.py
+++ b/src/paperless_mcp/models/correspondent.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from paperless_mcp.models._compat import UserId
+
 
 class Correspondent(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -17,7 +19,7 @@ class Correspondent(BaseModel):
     is_insensitive: bool = True
     document_count: int | None = None
     last_correspondence: datetime | None = None
-    owner: int | None = None
+    owner: UserId = None
     user_can_change: bool = True
 
 

--- a/src/paperless_mcp/models/document.py
+++ b/src/paperless_mcp/models/document.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from paperless_mcp.models._compat import UserId, Username
+
 
 class CustomFieldInstance(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -19,7 +21,7 @@ class DocumentNote(BaseModel):
     id: int
     note: str
     created: datetime
-    user: int | None = None
+    user: UserId = None
 
 
 class Document(BaseModel):
@@ -38,7 +40,7 @@ class Document(BaseModel):
     archive_serial_number: str | int | None = None
     original_file_name: str | None = None
     archived_file_name: str | None = None
-    owner: int | None = None
+    owner: UserId = None
     user_can_change: bool = True
     notes: list[DocumentNote] = Field(default_factory=list)
     custom_fields: list[CustomFieldInstance] = Field(default_factory=list)
@@ -79,7 +81,7 @@ class DocumentHistoryEntry(BaseModel):
     model_config = ConfigDict(extra="allow")
     timestamp: datetime
     action: str
-    actor: str | None = None
+    actor: Username = None
 
 
 class DocumentSuggestions(BaseModel):

--- a/src/paperless_mcp/models/document_type.py
+++ b/src/paperless_mcp/models/document_type.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from paperless_mcp.models._compat import UserId
+
 
 class DocumentType(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -14,7 +16,7 @@ class DocumentType(BaseModel):
     matching_algorithm: int | None = None
     is_insensitive: bool = True
     document_count: int | None = None
-    owner: int | None = None
+    owner: UserId = None
     user_can_change: bool = True
 
 

--- a/src/paperless_mcp/models/saved_view.py
+++ b/src/paperless_mcp/models/saved_view.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from paperless_mcp.models._compat import UserId
+
 
 class SavedView(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -17,4 +19,4 @@ class SavedView(BaseModel):
     sort_reverse: bool = False
     filter_rules: list[dict[str, Any]] = Field(default_factory=list)
     page_size: int | None = None
-    owner: int | None = None
+    owner: UserId = None

--- a/src/paperless_mcp/models/storage_path.py
+++ b/src/paperless_mcp/models/storage_path.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
 
+from paperless_mcp.models._compat import UserId
+
 
 class StoragePath(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -15,5 +17,5 @@ class StoragePath(BaseModel):
     matching_algorithm: int | None = None
     is_insensitive: bool = True
     document_count: int | None = None
-    owner: int | None = None
+    owner: UserId = None
     user_can_change: bool = True

--- a/src/paperless_mcp/models/tag.py
+++ b/src/paperless_mcp/models/tag.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from paperless_mcp.models._compat import UserId
+
 
 class Tag(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -19,7 +21,7 @@ class Tag(BaseModel):
     is_insensitive: bool = True
     is_inbox_tag: bool = False
     document_count: int | None = None
-    owner: int | None = None
+    owner: UserId = None
     user_can_change: bool = True
 
 

--- a/tests/unit/models/test_document.py
+++ b/tests/unit/models/test_document.py
@@ -52,6 +52,37 @@ def test_document_note_roundtrip() -> None:
     assert note.id == 5
 
 
+def test_document_note_accepts_nested_user_object() -> None:
+    """Newer Paperless-NGX returns ``user`` as a nested object, not a bare ID."""
+    note = DocumentNote.model_validate(
+        {
+            "id": 5,
+            "note": "hi",
+            "created": "2026-04-23T10:00:00Z",
+            "user": {
+                "id": 3,
+                "username": "peter",
+                "first_name": "Peter",
+                "last_name": "van Liesdonk",
+            },
+        }
+    )
+    assert note.user == 3
+
+
+def test_document_owner_accepts_nested_user_object() -> None:
+    """``owner`` likewise: collapses dict input down to the user ID."""
+    doc = Document.model_validate(
+        {
+            "id": 1,
+            "title": "x",
+            "created": "2026-04-23T10:00:00Z",
+            "owner": {"id": 7, "username": "alice"},
+        }
+    )
+    assert doc.owner == 7
+
+
 def test_document_metadata_accepts_empty() -> None:
     meta = DocumentMetadata.model_validate({})
     assert meta.model_dump(exclude_none=True) == {}
@@ -62,6 +93,19 @@ def test_document_history_entry_roundtrip() -> None:
         {"timestamp": "2026-04-23T10:00:00Z", "action": "modify", "actor": "peter"}
     )
     assert entry.action == "modify"
+    assert entry.actor == "peter"
+
+
+def test_document_history_entry_accepts_nested_actor_object() -> None:
+    """Newer Paperless-NGX returns ``actor`` as a nested user object."""
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "modify",
+            "actor": {"id": 3, "username": "peter", "first_name": "Peter"},
+        }
+    )
+    assert entry.actor == "peter"
 
 
 def test_document_suggestions_accepts_empty_lists() -> None:

--- a/tests/unit/models/test_document.py
+++ b/tests/unit/models/test_document.py
@@ -108,6 +108,37 @@ def test_document_history_entry_accepts_nested_actor_object() -> None:
     assert entry.actor == "peter"
 
 
+def test_user_id_rejects_dict_without_id_key() -> None:
+    """A dict without ``id`` is malformed upstream — surface it, don't drop it silently."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DocumentNote.model_validate(
+            {
+                "id": 5,
+                "note": "hi",
+                "created": "2026-04-23T10:00:00Z",
+                "user": {"username": "alice"},
+            }
+        )
+
+
+def test_username_rejects_dict_without_username_key() -> None:
+    """Same contract for ``actor``: a dict without ``username`` must raise."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DocumentHistoryEntry.model_validate(
+            {
+                "timestamp": "2026-04-23T10:00:00Z",
+                "action": "modify",
+                "actor": {"id": 3},
+            }
+        )
+
+
 def test_document_suggestions_accepts_empty_lists() -> None:
     s = DocumentSuggestions.model_validate(
         {"tags": [], "correspondents": [], "document_types": [], "dates": []}


### PR DESCRIPTION
Closes #9

## Summary

- Add `UserId` annotated type with a `BeforeValidator` that collapses `{"id": N, "username": ...}` dicts down to `N` and leaves bare ints / None untouched
- Add `Username` annotated type that extracts `username` from the same dict shape, for fields that historically held a username string (i.e. audit-log `actor`)
- Apply `UserId` to every `user` and `owner` field across the model layer (DocumentNote, Document, Tag, Correspondent, DocumentType, StoragePath, SavedView)
- Apply `Username` to `DocumentHistoryEntry.actor`
- Three new unit tests covering the new (dict) shape; existing tests still cover the legacy (bare scalar) shape

## Why this approach

Two shapes, one normalization per output type. Going wider (introducing a `UserRef` model with username/name fields exposed downstream) would change the JSON the LLM sees and isn't justified by any current consumer — every downstream tool/resource that touches these fields uses only the integer ID or the username string. We can revisit if a real need to surface richer user info appears.

The schema drift originated upstream in Paperless-NGX itself, not in our code; `BeforeValidator`s are the lightest fix that keeps both old and new instances working.

## Test plan

- [x] `uv run pytest -x -q` — 160/160 pass (1 integration skipped)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [ ] Once merged + image rebuilt, verify `get_document`, `get_document_notes`, `get_document_history`, `add_document_note` succeed against the live Paperless instance that surfaced the bug
- [ ] Clean up stray test note on document id 48 (see #9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)