### PR TITLE
chore(copier): update to v1.2.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v1.1.11
+_commit: v1.2.0
 _src_path: gh:pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: 'Paperless-NGX document management over MCP: search, tag, upload,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run mypy
-        run: uv run mypy src/
+        run: uv run mypy src/ tests/
 
   test:
     name: Test (Python ${{ matrix.python-version }})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,26 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 
 1. **CI passes** — `uv run pytest -x -q` all tests pass
 2. **Lint passes** — run in this exact order: `uv run ruff check --fix .` then `uv run ruff format .` then verify with `uv run ruff format --check .`. Always run format *after* check --fix because check --fix can leave files needing reformatting.
-3. **Type-check passes** — `uv run mypy src/` reports no errors
+3. **Type-check passes** — `uv run mypy src/ tests/` reports no errors
 4. **Patch coverage ≥ 80%** — Codecov measures only lines added/changed in the PR diff. Run `uv run pytest --cov=<changed_module> --cov-report=term-missing` and verify new code is exercised. Add tests for every uncovered branch before pushing.
 5. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
 6. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+
+## Pre-commit Hooks
+
+This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), mypy on `src/` and `tests/`, gitleaks secret scanning, and standard whitespace/YAML/JSON checks — aligned with the `ci.yml` lint/typecheck/secrets jobs so a clean pre-commit run implies a clean CI lane.
+
+- **Install once per clone:** `uv run pre-commit install`.
+- **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
+- **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
+
+The config is in `_skip_if_exists`, so domain-specific additions (shellcheck, yamllint, project-specific linters, additional file checks) on top of the shipped defaults survive `copier update`.
+
+## PR Discipline
+
+**Every PR must have at least one associated issue.** If the work doesn't have one yet — a bug found in the wild, an opportunistic cleanup, a small improvement — create the issue first, then open the PR with `Closes #N` (or `Refs #N`) in the body. A single PR may close multiple issues (`Closes #A, closes #B`) — bundling related fixes is fine; the rule is "no orphan PRs", not "one PR per issue". This keeps the changelog, release notes, and cross-repo history coherent.
+
+Trivial exceptions: pure typo fixes and automated dependency bumps (Dependabot / Renovate) may skip the issue.
 
 ## GitHub Review Types
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ For library usage (embedding the domain logic without the MCP transport), import
 
 ## Configuration
 
-<<<<<<< before updating
 All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
 
 ### Required
@@ -240,27 +239,16 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `paperless://documents/{document_id}/thumbnail` | Thumbnail image |
 | `paperless://documents/{document_id}/preview` | PDF preview |
 | `paperless://documents/{document_id}/download` | Original file download |
-=======
-Core environment variables shared across all `fastmcp-pvl-core`-based services:
+
+### Shared framework variables
+
+Inherited from `fastmcp-pvl-core` across all services built on the template:
 
 | Variable | Default | Description |
 |---|---|---|
 | `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
 | `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
 | `PAPERLESS_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
-
-Domain-specific variables go below under [Domain configuration](#domain-configuration).
-
-## Post-scaffold checklist
-
-After `copier copy` and `gh repo create --push`:
-
-1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
-2. Configure GitHub secrets — see below.
-3. Install dev dependencies: `uv sync --all-extras --dev`.
-4. Install pre-commit hooks: `uv run pre-commit install`.
-5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
-6. Push the first commit — CI should be green.
 
 ## GitHub secrets
 
@@ -310,7 +298,6 @@ uv sync --all-extras --dev
 ### `uv.lock` refresh after `copier update`
 
 When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
->>>>>>> after updating
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -9,29 +9,25 @@ Paperless-NGX document management over MCP: search, tag, upload, and read docume
 ## Features
 
 <!-- DOMAIN-START -->
-<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
-
-- **[Capability 1]** — one-sentence description of a user-visible feature.
-- **[Capability 2]** — one-sentence description of another capability.
-- **MCP tools** — N LLM-visible tools exposed; see `src/paperless_mcp/tools.py`.
-- **MCP resources** — M resources exposing domain state; see `src/paperless_mcp/resources.py`.
-- **MCP prompts** — K prompt templates; see `src/paperless_mcp/prompts.py`.
+- **Document search & retrieval** — full-text and filtered list queries against Paperless-NGX, plus access to extracted OCR text, metadata, thumbnails, and original-file downloads via short-lived signed URLs.
+- **Tag, correspondent, document-type, custom-field management** — full CRUD and bulk-edit for every classification dimension Paperless exposes.
+- **Document lifecycle** — upload new documents, update fields, attach notes, and inspect audit history and AI-suggested tags/correspondents/types.
+- **Operational introspection** — saved views, storage paths, share links, background tasks (with `wait_for_task`), statistics, and remote Paperless-NGX version.
+- **MCP tools** — 52 LLM-visible tools with Lucide icons and read-only gating; see `src/paperless_mcp/tools/`.
+- **MCP resources** — 20 URIs exposing documents and domain collections; see `src/paperless_mcp/resources/`.
+- **Read-only mode** — flip `PAPERLESS_MCP_READ_ONLY=true` to disable every mutating tool at startup.
 <!-- DOMAIN-END -->
 
 ## What you can do with it
 
 <!-- DOMAIN-START -->
-<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
-
 With this server mounted in an MCP client (Claude, etc.), you can:
 
-- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
-- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
-- **[Task 3]** — "[third example]."
-
-Short, concrete prompts beat abstract feature lists — replace the
-`[Task N]` placeholders with prompts that actually work against your
-server's tool surface.
+- **"Find last quarter's invoices from ACME."** Composes `search_documents` with a correspondent filter, then streams matches via `paperless://documents/{id}/content`.
+- **"Tag these three documents as 'reviewed' and move them to the Accounting correspondent."** Uses `bulk_edit_documents` in a single call.
+- **"Upload this PDF and wait until OCR finishes."** Composes `upload_document` + `wait_for_task` so the assistant only reports back once the document is indexed.
+- **"What changed on document 4213 in the last week?"** Reads `paperless://documents/4213/history` and summarises the audit trail.
+- **"Give me a time-limited link to the original file for document 982."** Calls `create_download_link` — the URL is valid for `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` and does not expose the API token.
 <!-- DOMAIN-END -->
 
 <!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
@@ -47,7 +43,7 @@ pip install pvliesdonk-paperless-mcp
 If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
 
 <!-- DOMAIN-START -->
-<!-- List optional extras and their purpose here (e.g. `pip install pvliesdonk-paperless-mcp[embeddings]`). Kept across copier update. -->
+- `pip install pvliesdonk-paperless-mcp[docs]` — pulls in `mkdocs-material` and `mkdocstrings[python]` for building the documentation site locally (`uv run mkdocs serve`).
 <!-- DOMAIN-END -->
 
 ### From source
@@ -311,22 +307,16 @@ When `copier update` introduces new dependencies (e.g. a new extra added to `pyp
 ## Domain configuration
 
 <!-- DOMAIN-START -->
-<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
-
-Domain environment variables use the `PAPERLESS_MCP_` prefix:
-
-| Variable | Default | Required | Description |
-|---|---|---|---|
-| `PAPERLESS_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
-| `PAPERLESS_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
-
-Domain-config fields are composed inside `src/paperless_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+The full domain env-var surface is documented under [Configuration](#configuration) above (Required / Optional tables). Those `PAPERLESS_MCP_*` fields are composed inside `src/paperless_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
 <!-- DOMAIN-END -->
 
 ## Key design decisions
 
 <!-- DOMAIN-START -->
-<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
-
-_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
+- **Read-only gating at startup, not per-call.** `PAPERLESS_MCP_READ_ONLY=true` skips registration of every mutating tool so they simply aren't part of the advertised tool surface — clients can't invoke a write that will be refused.
+- **Download links are signed and time-limited.** `create_download_link` mints a short-lived URL (default 300 s, clamped to `[30, 3600]`) that proxies through the MCP server, so the Paperless API token never leaves the host.
+- **HTTP layer retries idempotent reads only.** `PAPERLESS_MCP_HTTP_RETRIES` applies to GETs on 5xx/network errors; writes never retry automatically, to avoid double-applying bulk edits or uploads.
+- **Tool icons come from Lucide.** Every tool carries a Lucide icon hint so MCP clients that render icons (Claude Desktop) get a coherent visual surface — see `src/paperless_mcp/tools/_icons.py`.
+- **Models accept unknown upstream fields.** Pydantic models use lenient validation for list-endpoint responses so newer Paperless-NGX versions don't break the client (the `Document.some_future_paperless_field` test pins this behaviour).
+- **No prompts ship in v1.** `prompts.py` is intentionally empty; prompts land as concrete user-workflow patterns emerge in practice.
 <!-- DOMAIN-END -->

--- a/README.md
+++ b/README.md
@@ -1,17 +1,97 @@
 # Paperless MCP
 
+[![CI](https://github.com/pvliesdonk/paperless-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/pvliesdonk/paperless-mcp/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/pvliesdonk/paperless-mcp/graph/badge.svg)](https://codecov.io/gh/pvliesdonk/paperless-mcp) [![PyPI](https://img.shields.io/pypi/v/pvliesdonk-paperless-mcp)](https://pypi.org/project/pvliesdonk-paperless-mcp/) [![Python](https://img.shields.io/pypi/pyversions/pvliesdonk-paperless-mcp)](https://pypi.org/project/pvliesdonk-paperless-mcp/) [![License](https://img.shields.io/github/license/pvliesdonk/paperless-mcp)](LICENSE) [![Docker](https://img.shields.io/github/v/release/pvliesdonk/paperless-mcp?label=ghcr.io&logo=docker)](https://github.com/pvliesdonk/paperless-mcp/pkgs/container/paperless-mcp) [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://pvliesdonk.github.io/paperless-mcp/) [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://pvliesdonk.github.io/paperless-mcp/llms.txt)
+
 Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields.
+
+**[Documentation](https://pvliesdonk.github.io/paperless-mcp/)** | **[PyPI](https://pypi.org/project/pvliesdonk-paperless-mcp/)** | **[Docker](https://github.com/pvliesdonk/paperless-mcp/pkgs/container/paperless-mcp)**
+
+## Features
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-7 bullets describing what this MCP server does. Kept across copier update. -->
+
+- **[Capability 1]** — one-sentence description of a user-visible feature.
+- **[Capability 2]** — one-sentence description of another capability.
+- **MCP tools** — N LLM-visible tools exposed; see `src/paperless_mcp/tools.py`.
+- **MCP resources** — M resources exposing domain state; see `src/paperless_mcp/resources.py`.
+- **MCP prompts** — K prompt templates; see `src/paperless_mcp/prompts.py`.
+<!-- DOMAIN-END -->
+
+## What you can do with it
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-5 concrete "you can ask Claude to X" examples. Kept across copier update. -->
+
+With this server mounted in an MCP client (Claude, etc.), you can:
+
+- **[Task 1]** — "[example user request]." Composes tools `[tool_a]` + `[tool_b]`.
+- **[Task 2]** — "[another example request]." Uses resource `[resource_x]`.
+- **[Task 3]** — "[third example]."
+
+Short, concrete prompts beat abstract feature lists — replace the
+`[Task N]` placeholders with prompts that actually work against your
+server's tool surface.
+<!-- DOMAIN-END -->
+
+<!-- ===== TEMPLATE-OWNED SECTIONS BELOW — DO NOT EDIT; CHANGES WILL BE OVERWRITTEN ON COPIER UPDATE ===== -->
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install pvliesdonk-paperless-mcp
+```
+
+If you add optional extras via the `PROJECT-EXTRAS-START` / `PROJECT-EXTRAS-END` sentinels in `pyproject.toml`, document them below:
+
+<!-- DOMAIN-START -->
+<!-- List optional extras and their purpose here (e.g. `pip install pvliesdonk-paperless-mcp[embeddings]`). Kept across copier update. -->
+<!-- DOMAIN-END -->
+
+### From source
+
+```bash
+git clone https://github.com/pvliesdonk/paperless-mcp.git
+cd paperless-mcp
+uv sync --all-extras --dev
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/pvliesdonk/paperless-mcp:latest
+```
+
+A `compose.yml` ships at the repo root as a starting point — copy `.env.example` to `.env`, edit, and `docker compose up -d`.
+
+### Linux packages (.deb / .rpm)
+
+Download `.deb` or `.rpm` packages from the [GitHub Releases](https://github.com/pvliesdonk/paperless-mcp/releases) page. Both install a hardened systemd unit; env configuration is sourced from `/etc/paperless-mcp/env` (copy from the shipped `/etc/paperless-mcp/env.example`).
+
+### Claude Desktop (.mcpb bundle)
+
+Download the `.mcpb` bundle from the [GitHub Releases](https://github.com/pvliesdonk/paperless-mcp/releases) page and double-click to install, or run:
+
+```bash
+mcpb install paperless-mcp-<version>.mcpb
+```
+
+Claude Desktop prompts for required env vars via a GUI wizard — no manual JSON editing needed.
 
 ## Quick start
 
 ```bash
-pip install pvliesdonk-paperless-mcp
-paperless-mcp serve                                # stdio
-paperless-mcp serve --transport http --port 8000   # HTTP
+paperless-mcp serve                                # stdio transport
+paperless-mcp serve --transport http --port 8000   # streamable HTTP
 ```
+
+For library usage (embedding the domain logic without the MCP transport), import from the `paperless_mcp` package directly — see `src/paperless_mcp/domain.py` for the entry point scaffold.
 
 ## Configuration
 
+<<<<<<< before updating
 All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
 
 ### Required
@@ -160,9 +240,106 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `paperless://documents/{document_id}/thumbnail` | Thumbnail image |
 | `paperless://documents/{document_id}/preview` | PDF preview |
 | `paperless://documents/{document_id}/download` | Original file download |
+=======
+Core environment variables shared across all `fastmcp-pvl-core`-based services:
+
+| Variable | Default | Description |
+|---|---|---|
+| `FASTMCP_LOG_LEVEL` | `INFO` | Log level for FastMCP internals and app loggers (`DEBUG` / `INFO` / `WARNING` / `ERROR`). The `-v` CLI flag overrides to `DEBUG`. |
+| `FASTMCP_ENABLE_RICH_LOGGING` | `true` | Set to `false` for plain / structured JSON log output. |
+| `PAPERLESS_MCP_EVENT_STORE_URL` | `memory://` | Event store backend for HTTP session persistence — `memory://` (dev), `file:///path` (survives restarts). |
+
+Domain-specific variables go below under [Domain configuration](#domain-configuration).
+
+## Post-scaffold checklist
+
+After `copier copy` and `gh repo create --push`:
+
+1. **Fill in the DOMAIN blocks** in this README (Features, What you can do with it, Domain configuration, Key design decisions) and in `CLAUDE.md`.
+2. Configure GitHub secrets — see below.
+3. Install dev dependencies: `uv sync --all-extras --dev`.
+4. Install pre-commit hooks: `uv run pre-commit install`.
+5. Run the gate locally: `uv run pytest -x -q && uv run ruff check --fix . && uv run ruff format . && uv run mypy src/ tests/`.
+6. Push the first commit — CI should be green.
+
+## GitHub secrets
+
+CI workflows reference three repository secrets. Configure them via **Settings → Secrets and variables → Actions** or with `gh secret set`:
+
+| Secret | Used by | How to generate |
+|---|---|---|
+| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write` and `pull_requests: write` (the `copier-update` cron opens PRs). Scoped to this repo. |
+| `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io> — sign in with GitHub, add the repo, copy the upload token from the repo settings page. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+
+```bash
+gh secret set RELEASE_TOKEN
+gh secret set CODECOV_TOKEN
+gh secret set CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`GITHUB_TOKEN` is auto-provided — no action needed.
+
+## Local development
+
+The PR gate (matches CI):
+
+```bash
+uv run pytest -x -q                                  # tests
+uv run ruff check --fix . && uv run ruff format .    # lint + format
+uv run mypy src/ tests/                              # type-check
+```
+
+Pre-commit runs a subset of the gate on each commit; see `.pre-commit-config.yaml` for details, or [`CLAUDE.md`](CLAUDE.md) for the full Hard PR Acceptance Gates.
+
+## Troubleshooting
+
+### Moving a scaffolded project
+
+`uv sync` creates `.venv/bin/*` scripts with absolute shebangs pointing at the venv Python. If you move the repo after scaffolding (`mv /old/path /new/path`), `uv run pytest` fails with `ModuleNotFoundError: No module named 'fastmcp'` because the stale shebang resolves to a different interpreter than the venv's site-packages.
+
+**Fix:**
+
+```bash
+rm -rf .venv
+uv sync --all-extras --dev
+```
+
+`uv run python -m pytest` also works as a one-shot workaround (bypasses the stale entry-script shim).
+
+### `uv.lock` refresh after `copier update`
+
+When `copier update` introduces new dependencies (e.g. a new extra added to `pyproject.toml.jinja`), CI runs `uv sync --frozen` which fails against a stale lockfile. Run `uv lock` locally and commit the refreshed `uv.lock` alongside accepting the copier-update PR.
+>>>>>>> after updating
 
 ## Links
 
 - [Documentation](https://pvliesdonk.github.io/paperless-mcp/)
+- [llms.txt](https://pvliesdonk.github.io/paperless-mcp/llms.txt)
 - [FastMCP](https://gofastmcp.com)
 - [fastmcp-pvl-core](https://pypi.org/project/fastmcp-pvl-core/)
+
+<!-- ===== TEMPLATE-OWNED SECTIONS END ===== -->
+
+## Domain configuration
+
+<!-- DOMAIN-START -->
+<!-- Replace with a table of domain-specific env vars. Kept across copier update. -->
+
+Domain environment variables use the `PAPERLESS_MCP_` prefix:
+
+| Variable | Default | Required | Description |
+|---|---|---|---|
+| `PAPERLESS_MCP_EXAMPLE_VAR` | — | **Yes** | Replace this row with your first required setting. |
+| `PAPERLESS_MCP_ANOTHER_VAR` | `default` | No | Replace with an optional setting. |
+
+Domain-config fields are composed inside `src/paperless_mcp/config.py` between the `CONFIG-FIELDS-START` / `CONFIG-FIELDS-END` sentinels; env reads go through `fastmcp_pvl_core.env(_ENV_PREFIX, "SUFFIX", default)` so naming stays consistent.
+<!-- DOMAIN-END -->
+
+## Key design decisions
+
+<!-- DOMAIN-START -->
+<!-- Replace with 3-6 bullets describing non-obvious architectural decisions. Kept across copier update. -->
+
+_Replace this placeholder with a short list of the non-obvious design calls this service makes — e.g. "writes are append-only", "embeddings cached in SQLite", "auth uses OIDC bearer tokens". Three to six bullets is typically enough; link out to longer ADRs under `docs/decisions/` if you maintain any._
+<!-- DOMAIN-END -->

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -1,0 +1,19 @@
+# Paperless MCP environment configuration
+#
+# Installed to /etc/paperless-mcp/env.example.
+# Copy to /etc/paperless-mcp/env and edit for your deployment; the
+# systemd unit (/usr/lib/systemd/system/paperless-mcp.service) sources
+# /etc/paperless-mcp/env via EnvironmentFile=.
+
+# --- Logging ---
+# DEBUG | INFO | WARNING | ERROR
+FASTMCP_LOG_LEVEL=INFO
+# Set to false for plain/structured JSON output instead of Rich formatting.
+FASTMCP_ENABLE_RICH_LOGGING=true
+
+# --- Domain configuration ---
+# All domain env vars use the PAPERLESS_MCP_ prefix.
+# See the README and `paperless-mcp serve --help` for the full list.
+#
+# Example:
+# PAPERLESS_MCP_EXAMPLE_VAR=value

--- a/packaging/env.example
+++ b/packaging/env.example
@@ -4,6 +4,8 @@
 # Copy to /etc/paperless-mcp/env and edit for your deployment; the
 # systemd unit (/usr/lib/systemd/system/paperless-mcp.service) sources
 # /etc/paperless-mcp/env via EnvironmentFile=.
+#
+# See https://pvliesdonk.github.io/paperless-mcp/ for full docs.
 
 # --- Logging ---
 # DEBUG | INFO | WARNING | ERROR
@@ -11,9 +13,55 @@ FASTMCP_LOG_LEVEL=INFO
 # Set to false for plain/structured JSON output instead of Rich formatting.
 FASTMCP_ENABLE_RICH_LOGGING=true
 
-# --- Domain configuration ---
-# All domain env vars use the PAPERLESS_MCP_ prefix.
-# See the README and `paperless-mcp serve --help` for the full list.
-#
-# Example:
-# PAPERLESS_MCP_EXAMPLE_VAR=value
+# --- Paperless connection (required) ---
+# Base URL of the Paperless-NGX REST API (no trailing slash).
+PAPERLESS_MCP_PAPERLESS_URL=http://localhost:8000
+# Paperless service-account token. Generate under
+# Paperless Settings → My Account → Auth Token.
+PAPERLESS_MCP_API_TOKEN=
+
+# --- HTTP behaviour (optional) ---
+# Per-request HTTP timeout in seconds. (default: 30)
+#PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS=30
+# Retries (not counting the initial attempt) on 5xx / network errors. (default: 2)
+#PAPERLESS_MCP_HTTP_RETRIES=2
+
+# --- Tool behaviour (optional) ---
+# Default page_size for list tools. Clamped [1, 100]. (default: 25)
+#PAPERLESS_MCP_DEFAULT_PAGE_SIZE=25
+# TTL of URLs issued by create_download_link. Clamped [30, 3600]. (default: 300)
+#PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS=300
+# When true, disables every writable tool. (default: false)
+#PAPERLESS_MCP_READ_ONLY=false
+# Operator-supplied description appended to MCP instructions.
+#PAPERLESS_MCP_INSTRUCTIONS=
+
+# --- Transport (optional) ---
+# Server transport: stdio (default), http, or sse.
+#PAPERLESS_MCP_TRANSPORT=stdio
+# Bind host for HTTP/SSE transport. (default: 127.0.0.1)
+#PAPERLESS_MCP_HOST=127.0.0.1
+# Bind port for HTTP/SSE transport. (default: 8000)
+#PAPERLESS_MCP_PORT=8000
+# URL path prefix for HTTP transport. (default: /mcp)
+#PAPERLESS_MCP_HTTP_PATH=/mcp
+# Public base URL for artifact download links.
+#PAPERLESS_MCP_BASE_URL=
+
+# --- Authentication (optional; leave unset for no auth) ---
+# Simple bearer token auth. When set, clients must present this token.
+#PAPERLESS_MCP_BEARER_TOKEN=
+# OIDC discovery URL (e.g. https://auth.example.com/.well-known/openid-configuration).
+#PAPERLESS_MCP_OIDC_CONFIG_URL=
+# OIDC client credentials (required when OIDC auth is enabled).
+#PAPERLESS_MCP_OIDC_CLIENT_ID=
+#PAPERLESS_MCP_OIDC_CLIENT_SECRET=
+# Signing key for OIDC session JWTs. Critical on Linux — the ephemeral
+# default invalidates tokens on every service restart.
+#PAPERLESS_MCP_OIDC_JWT_SIGNING_KEY=
+# OIDC audience claim for token validation.
+#PAPERLESS_MCP_OIDC_AUDIENCE=
+# OIDC required scopes. (default: openid)
+#PAPERLESS_MCP_OIDC_REQUIRED_SCOPES=openid
+# Verify OIDC access token as JWT instead of id_token. (default: false)
+#PAPERLESS_MCP_OIDC_VERIFY_ACCESS_TOKEN=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ dependencies = [
 
 [project.optional-dependencies]
 # PROJECT-EXTRAS-START — add domain-specific optional-dependency groups below; kept across copier update
-docs = [
-    "mkdocs-material>=9",
-    "mkdocstrings[python]>=0.28",
-]
 # PROJECT-EXTRAS-END
 
 docs = [
@@ -85,7 +81,6 @@ ignore = ["E501"]
 "src/paperless_mcp/server.py" = ["TC003"]
 "src/paperless_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
 "src/paperless_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
-<<<<<<< before updating
 "src/paperless_mcp/tools/__init__.py" = ["B008", "TC001", "TC002"]
 "src/paperless_mcp/tools/_registry.py" = ["TC002", "TC003"]
 "src/paperless_mcp/tools/_icons.py" = ["TC002"]
@@ -103,14 +98,6 @@ ignore = ["E501"]
 "src/paperless_mcp/client/_http.py" = ["TC003"]
 # PaperlessHTTP is stored as self._http at runtime; TracebackType used in __aexit__.
 "src/paperless_mcp/client/*.py" = ["TC001", "TC002", "TC003"]
-=======
-"src/paperless_mcp/tools.py" = ["B008", "TC001", "TC002"]
-"src/paperless_mcp/resources.py" = ["B008", "TC001", "TC002"]
-"src/paperless_mcp/prompts.py" = ["B008", "TC002"]
-"tests/conftest.py" = ["TC002", "TC003"]
-"tests/test_smoke.py" = ["TC002"]
-"tests/test_tools.py" = ["TC002"]
->>>>>>> after updating
 # Add project-specific overrides below as needed.
 
 [tool.ruff.lint.isort]
@@ -157,6 +144,24 @@ no_implicit_optional = true
 module = ["fastmcp_pvl_core", "fastmcp_pvl_core.*"]
 ignore_missing_imports = true
 
+# Relax strict typing for the existing test suite — predates the template's
+# mypy-on-tests expansion.  Newly scaffolded tests (tests/test_cli.py) remain
+# fully typed; legacy unit tests can be annotated incrementally.  Module
+# names are unqualified (e.g. `client.test_documents_read`) because
+# `tests/` and `tests/unit/` have no `__init__.py`, so mypy resolves
+# packages starting from the nearest `__init__.py` directory.
+[[tool.mypy.overrides]]
+module = [
+    "client.*",
+    "models.*",
+    "resources.*",
+    "tools.*",
+    "integration.*",
+]
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+check_untyped_defs = false
+
 
 [tool.pyright]
 # Point Pyright at the uv-managed venv so editor diagnostics resolve
@@ -164,11 +169,8 @@ ignore_missing_imports = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
-<<<<<<< before updating
-=======
 # src-layout editable installs use a .pth shim that Pyright does not execute;
 # point Pyright at src/ directly so IDE import resolution matches runtime.
->>>>>>> after updating
 extraPaths = ["src"]
 
 [tool.semantic_release]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ docs = [
 ]
 # PROJECT-EXTRAS-END
 
+docs = [
+    "mkdocs-material>=9",
+    "mkdocstrings[python]>=0.28",
+]
+
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
@@ -80,6 +85,7 @@ ignore = ["E501"]
 "src/paperless_mcp/server.py" = ["TC003"]
 "src/paperless_mcp/_server_deps.py" = ["B008", "TC002", "TC003"]
 "src/paperless_mcp/_server_apps.py" = ["B008", "TC001", "TC002"]
+<<<<<<< before updating
 "src/paperless_mcp/tools/__init__.py" = ["B008", "TC001", "TC002"]
 "src/paperless_mcp/tools/_registry.py" = ["TC002", "TC003"]
 "src/paperless_mcp/tools/_icons.py" = ["TC002"]
@@ -97,6 +103,14 @@ ignore = ["E501"]
 "src/paperless_mcp/client/_http.py" = ["TC003"]
 # PaperlessHTTP is stored as self._http at runtime; TracebackType used in __aexit__.
 "src/paperless_mcp/client/*.py" = ["TC001", "TC002", "TC003"]
+=======
+"src/paperless_mcp/tools.py" = ["B008", "TC001", "TC002"]
+"src/paperless_mcp/resources.py" = ["B008", "TC001", "TC002"]
+"src/paperless_mcp/prompts.py" = ["B008", "TC002"]
+"tests/conftest.py" = ["TC002", "TC003"]
+"tests/test_smoke.py" = ["TC002"]
+"tests/test_tools.py" = ["TC002"]
+>>>>>>> after updating
 # Add project-specific overrides below as needed.
 
 [tool.ruff.lint.isort]
@@ -150,6 +164,11 @@ ignore_missing_imports = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+<<<<<<< before updating
+=======
+# src-layout editable installs use a .pth shim that Pyright does not execute;
+# point Pyright at src/ directly so IDE import resolution matches runtime.
+>>>>>>> after updating
 extraPaths = ["src"]
 
 [tool.semantic_release]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Client]:
+async def client(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Client[Any]]:
     """Return an in-memory FastMCP client connected to a fresh server."""
     monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.test")
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "test-token-do-not-use-in-prod")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,40 @@
+"""CLI tests for Paperless MCP.
+
+Uses the standard typer ``CliRunner`` pattern: ``--help`` exits via
+typer before any command body runs, so these tests don't import
+``server.py`` or start uvicorn — keeping them fast and free of side
+effects.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from paperless_mcp.cli import app
+
+
+def test_help_exits_zero() -> None:
+    """`paperless-mcp --help` lists the serve command."""
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "serve" in result.output
+
+
+def test_serve_help_exits_zero() -> None:
+    """`paperless-mcp serve --help` documents the transport flag."""
+    result = CliRunner().invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "stdio" in result.output
+
+
+def test_no_args_shows_help() -> None:
+    """Bare invocation shows help text via ``no_args_is_help=True``.
+
+    Typer/Click exits with code 2 (missing command) but still prints the
+    help output.  Pinning the exit code locks in the documented behaviour
+    so a future typer version that routes bare invocation to a different
+    code (e.g. 1 for runtime error) surfaces as a test failure.
+    """
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 2
+    assert "serve" in result.output

--- a/tests/unit/client/test_documents_read.py
+++ b/tests/unit/client/test_documents_read.py
@@ -54,7 +54,12 @@ async def test_list_documents_passes_filters(
 async def test_search_uses_query_param(
     documents: DocumentsClient, load_fixture
 ) -> None:
-    page = {"count": 0, "next": None, "previous": None, "results": []}
+    page: dict[str, object] = {
+        "count": 0,
+        "next": None,
+        "previous": None,
+        "results": [],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
         route = mock.get("/api/documents/").mock(
             return_value=httpx.Response(200, json=page)
@@ -67,7 +72,12 @@ async def test_search_uses_query_param(
 async def test_search_more_like_uses_more_like_id(
     documents: DocumentsClient, load_fixture
 ) -> None:
-    page = {"count": 0, "next": None, "previous": None, "results": []}
+    page: dict[str, object] = {
+        "count": 0,
+        "next": None,
+        "previous": None,
+        "results": [],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
         route = mock.get("/api/documents/").mock(
             return_value=httpx.Response(200, json=page)

--- a/tests/unit/models/test_common.py
+++ b/tests/unit/models/test_common.py
@@ -37,7 +37,7 @@ def test_paginated_parses_results() -> None:
         }
     )
     assert [r.id for r in page.results] == [1, 2]
-    assert page.results[0].extra == "hi"
+    assert page.results[0].extra == "hi"  # type: ignore[attr-defined]
 
 
 def test_bulk_edit_operation_enum() -> None:

--- a/tests/unit/models/test_document.py
+++ b/tests/unit/models/test_document.py
@@ -29,7 +29,7 @@ def test_document_full(load_fixture) -> None:
 
 def test_document_forward_compatible(load_fixture) -> None:
     doc = Document.model_validate(load_fixture("document_full.json"))
-    assert doc.some_future_paperless_field == "that we don't know about yet"
+    assert doc.some_future_paperless_field == "that we don't know about yet"  # type: ignore[attr-defined]
 
 
 def test_document_patch_strict_forbids_extra() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "0.1.0"
+version = "1.0.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Template update: `v1.1.11` → `v1.2.0`

[Compare on GitHub](https://github.com/pvliesdonk/fastmcp-server-template/compare/v1.1.11...v1.2.0)

<details><summary>Release notes (v1.2.0)</summary>

- #66 chore: mop-up — Gate #3 mypy scope + template-ci hardening
- #65 feat(readme): expand README.md.jinja into structured template with DOMAIN sentinels
- #63 feat: pre-commit gate + PR-issue discipline in template CLAUDE.md
- #62 fix: three scaffolding-time bugs blocking downstream CI and releases
- #54 Scaffold coverage + README post-setup (closes #50, #51)

</details>

<details><summary>Files changed (7)</summary>

```
 .copier-answers.yml      |   2 +-
 .github/workflows/ci.yml |   2 +-
 CLAUDE.md                |  18 ++++-
 README.md                | 183 ++++++++++++++++++++++++++++++++++++++++++++++-
 packaging/env.example    |  19 +++++
 pyproject.toml           |  19 +++++
 tests/test_cli.py        |  40 +++++++++++
 7 files changed, 277 insertions(+), 6 deletions(-)
```

</details>

### ⚠️ 2 file(s) with unresolved conflict markers

The `<<<<<<< before updating` markers **are committed to this branch** — resolve them before merging:

- `README.md`
- `pyproject.toml`

---

> **Note:** `--skip-answered` was passed, so any **new** template variables introduced since the last update were silently filled with their copier defaults. Skim `.copier-answers.yml` for unexpected new keys.