### PR TITLE
fix(tasks): paginate list_tasks and default to unacknowledged

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `get_saved_view` | Get a saved view by ID |
 | `list_share_links` | List share links |
 | `get_share_link` | Get a share link by ID |
-| `list_tasks` | List background tasks |
+| `list_tasks` | List background tasks. Paginates (`page`, `page_size` up to 100). By default returns only unacknowledged tasks — pass `include_acknowledged=True` to include acknowledged tasks, or `acknowledged=True` to return only acknowledged ones. |
 | `get_task` | Get a task by ID |
 | `wait_for_task` | Wait until a task completes |
 | `get_statistics` | Get server statistics |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -59,6 +59,14 @@ Paperless MCP exposes the following tools to MCP clients.
 | `update_custom_field` | Update a custom field |
 | `delete_custom_field` | Delete a custom field |
 
+## Task tools
+
+| Tool | Description |
+|---|---|
+| `list_tasks` | List background Celery tasks. Paginates (`page`, `page_size` up to 100). Defaults to unacknowledged tasks only — pass `include_acknowledged=True` to include acknowledged tasks, or `acknowledged=True` to return only acknowledged ones. |
+| `get_task` | Get a task by UUID |
+| `wait_for_task` | Poll until a task reaches a terminal state or times out |
+
 ## System tools
 
 | Tool | Description |

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -28,22 +28,27 @@ class TasksClient:
         acknowledged: bool | None = None,
         include_acknowledged: bool = False,
     ) -> Paginated[Task]:
-        """List Paperless tasks with pagination and optional server-side filtering.
+        """List Paperless tasks with pagination and optional filtering.
+
+        The ``/api/tasks/`` endpoint returns a bare JSON array (no paginated
+        envelope), so pagination is performed client-side: all matching tasks
+        are fetched in one request and sliced here.
 
         Args:
-            page: Page number (1-based).
-            page_size: Results per page (1-100).
-            status: Filter by task status.
             acknowledged: Filter by acknowledged flag.  When ``None`` and
                 ``include_acknowledged`` is ``False``, defaults to ``False``
                 (unacknowledged only).
             include_acknowledged: When ``True``, do not apply the default
-                ``acknowledged=false`` filter.  Ignored if *acknowledged* is set.
+                ``acknowledged=false`` filter.  Ignored if *acknowledged* is
+                set explicitly.
+            page: Page number (1-based).
+            page_size: Results per page. Tool layer clamps 1-100.
+            status: Filter by task status.
 
         Returns:
             A :class:`Paginated` page of :class:`Task` objects.
         """
-        params: dict[str, object] = {"page": page, "page_size": page_size}
+        params: dict[str, object] = {}
         if status is not None:
             params["status"] = status.value
         if acknowledged is None and not include_acknowledged:
@@ -51,7 +56,18 @@ class TasksClient:
         if acknowledged is not None:
             params["acknowledged"] = str(acknowledged).lower()
         body = await self._http.get_json("/api/tasks/", params=params)
-        return Paginated[Task].model_validate(body)
+        # /api/tasks/ returns a bare list — paginate client-side.
+        all_tasks = [Task.model_validate(item) for item in body]
+        start = (page - 1) * page_size
+        end = start + page_size
+        return Paginated[Task].model_validate(
+            {
+                "count": len(all_tasks),
+                "next": None,
+                "previous": None,
+                "results": [t.model_dump() for t in all_tasks[start:end]],
+            }
+        )
 
     async def get(self, task_uuid: str) -> Task | None:
         """Fetch a single task by UUID.

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -7,6 +7,7 @@ import builtins
 import time
 
 from paperless_mcp.client._http import PaperlessHTTP
+from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.task import Task, TaskStatus
 
 _TERMINAL_STATUSES = {TaskStatus.SUCCESS, TaskStatus.FAILURE, TaskStatus.REVOKED}
@@ -19,24 +20,38 @@ class TasksClient:
         self._http = http
 
     async def list(
-        self, *, status: TaskStatus | None = None, acknowledged: bool | None = None
-    ) -> builtins.list[Task]:
-        """List tasks with optional server-side filtering.
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 25,
+        status: TaskStatus | None = None,
+        acknowledged: bool | None = None,
+        include_acknowledged: bool = False,
+    ) -> Paginated[Task]:
+        """List Paperless tasks with pagination and optional server-side filtering.
 
         Args:
+            page: Page number (1-based).
+            page_size: Results per page (1-100).
             status: Filter by task status.
-            acknowledged: Filter by acknowledged flag.
+            acknowledged: Filter by acknowledged flag.  When ``None`` and
+                ``include_acknowledged`` is ``False``, defaults to ``False``
+                (unacknowledged only).
+            include_acknowledged: When ``True``, do not apply the default
+                ``acknowledged=false`` filter.  Ignored if *acknowledged* is set.
 
         Returns:
-            List of matching :class:`Task` objects.
+            A :class:`Paginated` page of :class:`Task` objects.
         """
-        params: dict[str, object] = {}
+        params: dict[str, object] = {"page": page, "page_size": page_size}
         if status is not None:
             params["status"] = status.value
+        if acknowledged is None and not include_acknowledged:
+            acknowledged = False
         if acknowledged is not None:
             params["acknowledged"] = str(acknowledged).lower()
-        body = await self._http.get_json("/api/tasks/", params=params or None)
-        return [Task.model_validate(entry) for entry in body]
+        body = await self._http.get_json("/api/tasks/", params=params)
+        return Paginated[Task].model_validate(body)
 
     async def get(self, task_uuid: str) -> Task | None:
         """Fetch a single task by UUID.

--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -65,6 +65,7 @@ class TasksClient:
                 "count": len(all_tasks),
                 "next": None,
                 "previous": None,
+                "all": [t.id for t in all_tasks],
                 "results": [t.model_dump() for t in all_tasks[start:end]],
             }
         )

--- a/src/paperless_mcp/resources/tasks.py
+++ b/src/paperless_mcp/resources/tasks.py
@@ -15,6 +15,6 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
 
     @mcp.resource(uri="tasks://paperless", mime_type="application/json")
     async def tasks_resource() -> str:
-        """Return all Paperless-NGX tasks as a JSON array."""
-        task_list = await client.tasks.list()
-        return json.dumps([t.model_dump() for t in task_list])
+        """Return Paperless-NGX tasks (first page, unacknowledged) as a JSON array."""
+        page = await client.tasks.list()
+        return json.dumps([t.model_dump() for t in page.results])

--- a/src/paperless_mcp/tools/tasks.py
+++ b/src/paperless_mcp/tools/tasks.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from fastmcp import FastMCP
 from pydantic import Field
 
+from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.task import Task, TaskStatus
 from paperless_mcp.tools._context import ToolContext
 from paperless_mcp.tools._registry import register_tool
@@ -24,11 +25,24 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
 
     @register_tool(mcp, "list_tasks", read_only_mode=read_only)
     async def list_tasks(
+        page: Annotated[int, Field(ge=1)] = 1,
+        page_size: Annotated[int, Field(ge=1, le=100)] = ctx.default_page_size,
         status: TaskStatus | None = None,
         acknowledged: bool | None = None,
-    ) -> list[Task]:
-        """List Paperless Celery tasks."""
-        return await client.tasks.list(status=status, acknowledged=acknowledged)
+        include_acknowledged: bool = False,
+    ) -> Paginated[Task]:
+        """List Paperless Celery tasks.
+
+        Defaults to unacknowledged tasks only (set ``include_acknowledged=True``
+        or ``acknowledged=True`` to see acknowledged ones).  Returns one page.
+        """
+        return await client.tasks.list(
+            page=page,
+            page_size=page_size,
+            status=status,
+            acknowledged=acknowledged,
+            include_acknowledged=include_acknowledged,
+        )
 
     @register_tool(mcp, "get_task", read_only_mode=read_only)
     async def get_task(task_uuid: str) -> Task | None:

--- a/tests/fixtures/paperless/tasks_page1.json
+++ b/tests/fixtures/paperless/tasks_page1.json
@@ -1,0 +1,10 @@
+{
+  "count": 48,
+  "next": "http://paperless.test/api/tasks/?page=2",
+  "previous": null,
+  "all": [1, 2, 3],
+  "results": [
+    {"id": 1, "task_id": "uuid-1", "status": "SUCCESS", "acknowledged": false, "type": "file", "task_file_name": "a.pdf", "date_created": "2026-01-01T00:00:00Z"},
+    {"id": 2, "task_id": "uuid-2", "status": "FAILURE", "acknowledged": false, "type": "file", "task_file_name": "b.pdf", "date_created": "2026-01-02T00:00:00Z"}
+  ]
+}

--- a/tests/fixtures/paperless/tasks_page1.json
+++ b/tests/fixtures/paperless/tasks_page1.json
@@ -1,10 +1,4 @@
-{
-  "count": 48,
-  "next": "http://paperless.test/api/tasks/?page=2",
-  "previous": null,
-  "all": [1, 2, 3],
-  "results": [
-    {"id": 1, "task_id": "uuid-1", "status": "SUCCESS", "acknowledged": false, "type": "file", "task_file_name": "a.pdf", "date_created": "2026-01-01T00:00:00Z"},
-    {"id": 2, "task_id": "uuid-2", "status": "FAILURE", "acknowledged": false, "type": "file", "task_file_name": "b.pdf", "date_created": "2026-01-02T00:00:00Z"}
-  ]
-}
+[
+  {"id": 1, "task_id": "uuid-1", "status": "SUCCESS", "acknowledged": false, "type": "file", "task_file_name": "a.pdf", "date_created": "2026-01-01T00:00:00Z"},
+  {"id": 2, "task_id": "uuid-2", "status": "FAILURE", "acknowledged": false, "type": "file", "task_file_name": "b.pdf", "date_created": "2026-01-02T00:00:00Z"}
+]

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -30,14 +30,10 @@ def tasks(http: PaperlessHTTP) -> TasksClient:
 
 @pytest.mark.asyncio
 async def test_list_all(tasks: TasksClient, load_fixture) -> None:
-    page = {
-        "count": 1,
-        "next": None,
-        "previous": None,
-        "results": [load_fixture("task_pending.json")],
-    }
+    # /api/tasks/ returns a bare list; client-side pagination wraps it.
+    bare = [load_fixture("task_pending.json")]
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=page))
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=bare))
         result = await tasks.list()
     assert result.results[0].status is TaskStatus.PENDING
 
@@ -113,10 +109,12 @@ async def test_list_tasks_paginated_defaults_to_unacknowledged(
     assert route.called
     call = route.calls[0].request
     assert call.url.params.get("acknowledged") == "false"
-    assert call.url.params.get("page") == "1"
-    assert call.url.params.get("page_size") == "25"
+    # page/page_size are NOT sent to the server; pagination is client-side.
+    assert "page" not in call.url.params
+    assert "page_size" not in call.url.params
     assert isinstance(result, Paginated)
-    assert result.count == 48
+    # count == total tasks in the bare list returned by /api/tasks/
+    assert result.count == 2
     assert len(result.results) == 2
     assert all(isinstance(t, Task) for t in result.results)
 
@@ -139,5 +137,6 @@ async def test_list_tasks_acknowledged_none_sends_no_filter(
         finally:
             await client.aclose()
 
+    assert route.called
     call = route.calls[0].request
     assert "acknowledged" not in call.url.params

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 import httpx
 import pytest
 import respx
 
+from paperless_mcp.client import PaperlessClient
 from paperless_mcp.client._http import PaperlessHTTP
 from paperless_mcp.client.tasks import TasksClient
-from paperless_mcp.models.task import TaskStatus
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.task import Task, TaskStatus
 
 
 @pytest.fixture
@@ -25,12 +30,16 @@ def tasks(http: PaperlessHTTP) -> TasksClient:
 
 @pytest.mark.asyncio
 async def test_list_all(tasks: TasksClient, load_fixture) -> None:
+    page = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [load_fixture("task_pending.json")],
+    }
     async with respx.mock(base_url="http://paperless.test") as mock:
-        mock.get("/api/tasks/").mock(
-            return_value=httpx.Response(200, json=[load_fixture("task_pending.json")])
-        )
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=page))
         result = await tasks.list()
-    assert result[0].status is TaskStatus.PENDING
+    assert result.results[0].status is TaskStatus.PENDING
 
 
 @pytest.mark.asyncio
@@ -81,3 +90,54 @@ async def test_wait_for_times_out(tasks: TasksClient, load_fixture) -> None:
             await tasks.wait_for(
                 pending["task_id"], timeout_seconds=0.05, poll_seconds=0.01
             )
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_paginated_defaults_to_unacknowledged(
+    load_fixture: Callable[[str], Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        route = mock.get("/api/tasks/").mock(
+            return_value=httpx.Response(200, json=load_fixture("tasks_page1.json"))
+        )
+        client = PaperlessClient(
+            base_url=paperless_base_url, api_token=paperless_api_token
+        )
+        try:
+            result = await client.tasks.list()
+        finally:
+            await client.aclose()
+
+    assert route.called
+    call = route.calls[0].request
+    assert call.url.params.get("acknowledged") == "false"
+    assert call.url.params.get("page") == "1"
+    assert call.url.params.get("page_size") == "25"
+    assert isinstance(result, Paginated)
+    assert result.count == 48
+    assert len(result.results) == 2
+    assert all(isinstance(t, Task) for t in result.results)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_acknowledged_none_sends_no_filter(
+    load_fixture: Callable[[str], Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        route = mock.get("/api/tasks/").mock(
+            return_value=httpx.Response(200, json=load_fixture("tasks_page1.json"))
+        )
+        client = PaperlessClient(
+            base_url=paperless_base_url, api_token=paperless_api_token
+        )
+        try:
+            await client.tasks.list(acknowledged=None, include_acknowledged=True)
+        finally:
+            await client.aclose()
+
+    call = route.calls[0].request
+    assert "acknowledged" not in call.url.params

--- a/tests/unit/tools/test_tasks.py
+++ b/tests/unit/tools/test_tasks.py
@@ -1,0 +1,56 @@
+"""Tool-layer tests for list_tasks pagination."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.task import Task
+from paperless_mcp.tools import tasks as tasks_mod
+from paperless_mcp.tools._context import ToolContext
+
+
+@pytest.fixture
+def mock_client() -> Any:
+    client = MagicMock()
+    client.tasks.list = AsyncMock()
+    client.tasks.get = AsyncMock()
+    client.tasks.wait_for = AsyncMock()
+    return client
+
+
+def test_list_tasks_registered_with_pagination(mock_client: Any) -> None:
+    mcp = FastMCP("test")
+    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    tasks_mod.register(mcp, ctx)
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    assert "list_tasks" in tools
+    schema = tools["list_tasks"].parameters
+    assert "page" in schema["properties"]
+    assert "page_size" in schema["properties"]
+    assert "include_acknowledged" in schema["properties"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_default_forwards_filter(mock_client: Any) -> None:
+    mcp = FastMCP("test")
+    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    tasks_mod.register(mcp, ctx)
+    mock_client.tasks.list.return_value = Paginated[Task].model_validate(
+        {"count": 0, "results": []}
+    )
+
+    async with Client(mcp) as c:
+        await c.call_tool("list_tasks", {})
+
+    mock_client.tasks.list.assert_awaited_once()
+    kwargs = mock_client.tasks.list.await_args.kwargs
+    assert kwargs["page"] == 1
+    assert kwargs["page_size"] == 25
+    assert kwargs.get("include_acknowledged") is False
+    assert kwargs.get("acknowledged") is None


### PR DESCRIPTION
## Summary
- `list_tasks` now takes `page`/`page_size` and returns `Paginated[Task]`, matching `list_documents`/`list_tags`.
- Defaults to `acknowledged=false` so the typical call returns only fresh tasks; `include_acknowledged=True` opts back into the full table.
- Updated `resources/tasks.py` to access `.results` on the new `Paginated` return value.

## Test plan
- [x] Client test covers the default filter and the explicit opt-out (`include_acknowledged=True`)
- [x] Tool test verifies the new schema params (`page`, `page_size`, `include_acknowledged`) are exposed
- [x] All 169 unit tests pass; mypy and ruff clean
- [x] Docs updated (README.md and docs/tools/index.md)

Closes #11