### PR TITLE
feat(documents): strip OCR content from list/search by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 
 | Tool | Description |
 |---|---|
-| `list_documents` | List documents with optional filtering |
-| `search_documents` | Full-text search across documents |
+| `list_documents` | List documents with optional filtering; OCR `content` stripped by default — pass `include_content=True` for full text |
+| `search_documents` | Full-text search across documents; OCR `content` stripped by default — pass `include_content=True` for full text |
 | `get_document` | Retrieve a document by ID |
 | `get_document_content` | Get the extracted text content of a document |
 | `get_document_thumbnail` | Get the thumbnail image of a document |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -6,7 +6,8 @@ Paperless MCP exposes the following tools to MCP clients.
 
 | Tool | Description |
 |---|---|
-| `search_documents` | Full-text and filtered document search |
+| `list_documents` | List documents with optional filters; OCR `content` stripped by default (`include_content=True` to opt in) |
+| `search_documents` | Full-text and filtered document search; OCR `content` stripped by default (`include_content=True` to opt in) |
 | `get_document` | Retrieve document metadata by ID |
 | `get_document_content` | Retrieve the plain-text content of a document |
 | `create_document` | Upload a new document for ingestion |

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -39,6 +39,7 @@ class DocumentsClient:
         document_type: int | None = None,
         storage_path: int | None = None,
         custom_field: int | None = None,
+        include_content: bool = False,
     ) -> Paginated[Document]:
         """List documents with optional server-side filtering.
 
@@ -51,6 +52,9 @@ class DocumentsClient:
             document_type: Filter by document type ID.
             storage_path: Filter by storage path ID.
             custom_field: Filter by custom field ID.
+            include_content: When ``False`` (default), strips the OCR
+                ``content`` field from every result to keep responses small.
+                Set to ``True`` to retain the full text.
 
         Returns:
             Paginated list of matching :class:`Document` objects.
@@ -69,7 +73,11 @@ class DocumentsClient:
         if custom_field is not None:
             params["custom_fields__id"] = custom_field
         body = await self._http.get_json("/api/documents/", params=params)
-        return Paginated[Document].model_validate(body)
+        result = Paginated[Document].model_validate(body)
+        if not include_content:
+            for doc in result.results:
+                doc.content = None
+        return result
 
     async def search(
         self,
@@ -78,6 +86,7 @@ class DocumentsClient:
         page: int = 1,
         page_size: int = 25,
         more_like: int | None = None,
+        include_content: bool = False,
     ) -> Paginated[Document]:
         """Full-text search for documents.
 
@@ -86,6 +95,9 @@ class DocumentsClient:
             page: Page number (1-based).
             page_size: Number of results per page.
             more_like: Return documents similar to this document ID.
+            include_content: When ``False`` (default), strips the OCR
+                ``content`` field from every hit to keep responses small.
+                Set to ``True`` to retain the full text.
 
         Returns:
             Paginated list of matching :class:`Document` objects.
@@ -96,7 +108,11 @@ class DocumentsClient:
         if query:
             params["query"] = query
         body = await self._http.get_json("/api/documents/", params=params)
-        return Paginated[Document].model_validate(body)
+        result = Paginated[Document].model_validate(body)
+        if not include_content:
+            for doc in result.results:
+                doc.content = None
+        return result
 
     async def get(self, document_id: int) -> Document:
         """Fetch a single document by ID.

--- a/src/paperless_mcp/tools/documents.py
+++ b/src/paperless_mcp/tools/documents.py
@@ -47,8 +47,13 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         document_type: int | None = None,
         storage_path: int | None = None,
         custom_field: int | None = None,
+        include_content: bool = False,
     ) -> Paginated[Document]:
-        """List documents with optional filters.  Returns one page."""
+        """List documents with optional filters.  Returns one page.
+
+        By default, per-document OCR ``content`` is stripped to keep results
+        small.  Pass ``include_content=True`` for the full text on each hit.
+        """
         return await client.documents.list(
             page=page,
             page_size=page_size,
@@ -58,6 +63,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
             document_type=document_type,
             storage_path=storage_path,
             custom_field=custom_field,
+            include_content=include_content,
         )
 
     @register_tool(mcp, "search_documents", read_only_mode=read_only)
@@ -66,10 +72,20 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         page: Annotated[int, Field(ge=1)] = 1,
         page_size: Annotated[int, Field(ge=1, le=100)] = ctx.default_page_size,
         more_like: int | None = None,
+        include_content: bool = False,
     ) -> Paginated[Document]:
-        """Full-text search documents.  Use *more_like* for similarity search."""
+        """Full-text search documents.
+
+        By default per-hit OCR ``content`` is stripped; pass
+        ``include_content=True`` to get full OCR text per hit.
+        Use *more_like* for similarity search.
+        """
         return await client.documents.search(
-            query, page=page, page_size=page_size, more_like=more_like
+            query,
+            page=page,
+            page_size=page_size,
+            more_like=more_like,
+            include_content=include_content,
         )
 
     @register_tool(mcp, "get_document", read_only_mode=read_only)

--- a/tests/unit/client/test_documents_list_search.py
+++ b/tests/unit/client/test_documents_list_search.py
@@ -1,0 +1,84 @@
+"""Tests for list/search content-stripping behaviour."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from paperless_mcp.client import PaperlessClient
+
+
+@pytest.fixture
+def _documents_page() -> dict[str, Any]:
+    return {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "all": [42],
+        "results": [
+            {
+                "id": 42,
+                "title": "Big PDF",
+                "content": "A" * 50_000,
+                "created": "2026-01-01T00:00:00Z",
+                "tags": [],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_strips_content_by_default(
+    _documents_page: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.list()
+        finally:
+            await c.aclose()
+    assert result.results[0].content is None
+
+
+@pytest.mark.asyncio
+async def test_list_keeps_content_when_include_content_true(
+    _documents_page: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.list(include_content=True)
+        finally:
+            await c.aclose()
+    assert result.results[0].content == "A" * 50_000
+
+
+@pytest.mark.asyncio
+async def test_search_strips_content_by_default(
+    _documents_page: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.search("foo")
+        finally:
+            await c.aclose()
+    assert result.results[0].content is None

--- a/tests/unit/client/test_documents_list_search.py
+++ b/tests/unit/client/test_documents_list_search.py
@@ -82,3 +82,21 @@ async def test_search_strips_content_by_default(
         finally:
             await c.aclose()
     assert result.results[0].content is None
+
+
+@pytest.mark.asyncio
+async def test_search_keeps_content_when_include_content_true(
+    _documents_page: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.search("foo", include_content=True)
+        finally:
+            await c.aclose()
+    assert result.results[0].content == "A" * 50_000

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -93,3 +93,14 @@ def test_all_tools_have_icons(mock_client: Any) -> None:
     tools = asyncio.run(mcp.list_tools())
     for tool in tools:
         assert tool.icons, f"tool {tool.name} missing icons"
+
+
+def test_list_and_search_expose_include_content(mock_client: Any) -> None:
+    mcp = FastMCP("test")
+    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    documents_mod.register(mcp, ctx)
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    for name in ("list_documents", "search_documents"):
+        schema = tools[name].parameters
+        assert "include_content" in schema["properties"]
+        assert schema["properties"]["include_content"].get("default") is False


### PR DESCRIPTION
## Summary

- `list_documents` and `search_documents` now omit the full OCR `content` per hit by default, keeping responses lean for MCP clients.
- Opt back in with `include_content=True` on either tool.
- `get_document`, `get_document_content`, and all other single-document endpoints are unchanged.

## Test plan

- [x] New client tests (`tests/unit/client/test_documents_list_search.py`) cover: default-strip for list, opt-in for list, default-strip for search
- [x] Tool schema test (`test_list_and_search_expose_include_content`) verifies both tools expose `include_content` with default `False`
- [x] All 169 tests pass; `client/documents.py` holds 80% coverage; `tools/documents.py` patch lines covered
- [x] README and `docs/tools/index.md` updated

Closes #13