### PR TITLE
docs(custom-fields): describe extra_data shape per data_type

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -64,7 +64,7 @@ Paperless MCP exposes the following tools to MCP clients.
 
 The `extra_data` field shape depends on the custom field's `data_type`. Refer to these shapes when using `create_custom_field` and `update_custom_field`:
 
-| `data_type` | Required `extra_data` shape | Notes |
+| `data_type` | `extra_data` shape / example | Notes |
 |---|---|---|
 | `string`, `longtext`, `integer`, `boolean`, `float`, `date`, `url`, `documentlink` | — (unused) | Omit or pass `null` |
 | `monetary` | `{"default_currency": "USD"}` | Optional ISO-4217 currency code; Paperless accepts `null`/absent |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -60,6 +60,18 @@ Paperless MCP exposes the following tools to MCP clients.
 | `update_custom_field` | Update a custom field |
 | `delete_custom_field` | Delete a custom field |
 
+### extra_data by data_type
+
+The `extra_data` field shape depends on the custom field's `data_type`. Refer to these shapes when using `create_custom_field` and `update_custom_field`:
+
+| `data_type` | Required `extra_data` shape | Notes |
+|---|---|---|
+| `string`, `longtext`, `integer`, `boolean`, `float`, `date`, `url`, `documentlink` | — (unused) | Omit or pass `null` |
+| `monetary` | `{"default_currency": "USD"}` | Optional ISO-4217 currency code; Paperless accepts `null`/absent |
+| `select` | `{"select_options": [{"label": "Low"}, {"label": "Medium"}]}` | **Required** on create. Paperless assigns each option a stable `id` on creation. On update, re-use existing `id` values to preserve document values. |
+
+Unknown shapes are rejected by Paperless with a 400 error.
+
 ## Task tools
 
 | Tool | Description |

--- a/src/paperless_mcp/tools/custom_fields.py
+++ b/src/paperless_mcp/tools/custom_fields.py
@@ -52,7 +52,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         - ``string``, ``longtext``, ``integer``, ``boolean``, ``float``,
           ``date``, ``url``, ``documentlink`` — unused; omit or pass ``null``.
         - ``monetary`` — optional ``{"default_currency": "USD"}`` (ISO-4217).
-        - ``select`` — required
+        - ``select`` — ``extra_data`` **required**:
           ``{"select_options": [{"label": "Low"}, {"label": "Medium"}]}``.
           Paperless assigns each option a stable ``id`` on creation.
 
@@ -66,12 +66,16 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     ) -> CustomField:
         """Patch selected fields on a custom field definition.
 
-        For ``select`` fields, ``extra_data.select_options`` replaces the
-        current list wholesale.  To preserve existing values, include each
-        existing option with its server-assigned ``id``:
-        ``{"select_options": [{"id": "abc", "label": "Low"}, ...]}``.
-        Omitting an option's ``id`` creates a new option; dropping an option
-        from the list deletes it and any document values referencing it.
+        ``extra_data`` shape depends on ``data_type``:
+
+        - ``monetary`` — optional ``{"default_currency": "USD"}`` (ISO-4217).
+        - ``select`` — ``extra_data.select_options`` replaces the current list
+          wholesale.  To preserve existing values, include each existing option
+          with its server-assigned ``id``:
+          ``{"select_options": [{"id": "abc", "label": "Low"}, ...]}``.
+          Omitting an option's ``id`` creates a new option; dropping an option
+          from the list deletes it and any document values referencing it.
+
         See ``create_custom_field`` for the full ``extra_data`` shape table.
         """
         return await client.custom_fields.update(field_id, patch)

--- a/src/paperless_mcp/tools/custom_fields.py
+++ b/src/paperless_mcp/tools/custom_fields.py
@@ -45,14 +45,35 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
 
     @register_tool(mcp, "create_custom_field", read_only_mode=read_only)
     async def create_custom_field(body: CustomFieldCreate) -> CustomField:
-        """Create a new custom field."""
+        """Create a new custom field.
+
+        ``extra_data`` depends on ``data_type``:
+
+        - ``string``, ``longtext``, ``integer``, ``boolean``, ``float``,
+          ``date``, ``url``, ``documentlink`` — unused; omit or pass ``null``.
+        - ``monetary`` — optional ``{"default_currency": "USD"}`` (ISO-4217).
+        - ``select`` — required
+          ``{"select_options": [{"label": "Low"}, {"label": "Medium"}]}``.
+          Paperless assigns each option a stable ``id`` on creation.
+
+        Unknown shapes are rejected by Paperless with a 400.
+        """
         return await client.custom_fields.create(body)
 
     @register_tool(mcp, "update_custom_field", read_only_mode=read_only)
     async def update_custom_field(
         field_id: int, patch: CustomFieldPatch
     ) -> CustomField:
-        """Patch selected fields on a custom field definition."""
+        """Patch selected fields on a custom field definition.
+
+        For ``select`` fields, ``extra_data.select_options`` replaces the
+        current list wholesale.  To preserve existing values, include each
+        existing option with its server-assigned ``id``:
+        ``{"select_options": [{"id": "abc", "label": "Low"}, ...]}``.
+        Omitting an option's ``id`` creates a new option; dropping an option
+        from the list deletes it and any document values referencing it.
+        See ``create_custom_field`` for the full ``extra_data`` shape table.
+        """
         return await client.custom_fields.update(field_id, patch)
 
     @register_tool(mcp, "delete_custom_field", read_only_mode=read_only)

--- a/tests/unit/tools/test_crud_resources.py
+++ b/tests/unit/tools/test_crud_resources.py
@@ -103,3 +103,16 @@ def test_read_write_registers_all(module: Any, prefix: str) -> None:
         f"bulk_edit_{prefix}s",
     }
     assert expected.issubset(names)
+
+
+def test_custom_field_tool_descriptions_mention_select_options() -> None:
+    """Regression test: docstrings document extra_data.select_options shape."""
+    mcp = FastMCP("test")
+    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    custom_fields_mod.register(mcp, ctx)
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    for name in ("create_custom_field", "update_custom_field"):
+        desc = tools[name].description or ""
+        assert "select_options" in desc, (
+            f"Tool {name!r} description must mention 'select_options'; got: {desc!r}"
+        )


### PR DESCRIPTION
## Summary
- Tool docstrings for `create_custom_field` and `update_custom_field` now document `extra_data` per `data_type`.
- Includes a shape table in the docs site and a regression test asserting the docstrings mention `select_options`.

## Paperless version referenced
- Paperless-NGX `src/documents/serialisers.py` — `CustomFieldSerializer`

## Test plan
- [x] Docstring regression test passes
- [x] Docs page renders the extra_data table
- [x] All tests pass
- [x] Linting and type-check pass

Closes #14