### PR TITLE
fix(tools): surface HTTPStatusError and ValidationError in tool wrapper

### DIFF
--- a/src/paperless_mcp/tools/_registry.py
+++ b/src/paperless_mcp/tools/_registry.py
@@ -19,6 +19,7 @@ from typing import TypeVar
 import httpx
 from fastmcp import FastMCP
 from mcp.types import Icon
+from pydantic import ValidationError as PydanticValidationError
 
 from paperless_mcp.client._errors import PaperlessAPIError
 
@@ -38,9 +39,23 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
                 "tool_api_error tool=%s status=%s msg=%s", name, exc.status_code, exc
             )
             return f"Paperless API error {exc.status_code}: {exc.detail}"
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "tool_http_status_error tool=%s status=%s url=%s",
+                name,
+                exc.response.status_code,
+                exc.request.url,
+            )
+            return (
+                f"Paperless API error {exc.response.status_code}: "
+                f"{exc.response.text or exc.response.reason_phrase}"
+            )
         except httpx.RequestError as exc:
             logger.warning("tool_network_error tool=%s error=%s", name, exc)
             return f"Network error connecting to Paperless: {exc}"
+        except PydanticValidationError as exc:
+            logger.warning("tool_validation_error tool=%s msg=%s", name, exc)
+            return f"Response validation failed: {exc}"
 
     return wrapper  # type: ignore[return-value]
 

--- a/src/paperless_mcp/tools/_registry.py
+++ b/src/paperless_mcp/tools/_registry.py
@@ -21,7 +21,7 @@ from fastmcp import FastMCP
 from mcp.types import Icon
 from pydantic import ValidationError as PydanticValidationError
 
-from paperless_mcp.client._errors import PaperlessAPIError
+from paperless_mcp.client._errors import PaperlessAPIError, error_from_response
 
 F = TypeVar("F", bound=Callable[..., object])
 
@@ -29,14 +29,11 @@ F = TypeVar("F", bound=Callable[..., object])
 logger = logging.getLogger(__name__)
 
 
-_MAX_ERROR_BODY = 500
-
-
-def _truncate(text: str, max_len: int = _MAX_ERROR_BODY) -> str:
-    return text if len(text) <= max_len else text[:max_len] + "…"
-
-
 def _wrap_with_error_handling(name: str, func: F) -> F:
+    # ``PaperlessHTTP`` normally maps non-2xx and network errors into
+    # ``PaperlessAPIError`` before they reach us, so the two ``httpx.*``
+    # branches below are defensive safety nets for any call path that
+    # bypasses ``PaperlessHTTP._request`` (e.g. future one-off httpx calls).
     @functools.wraps(func)
     async def wrapper(*args: object, **kwargs: object) -> object:
         try:
@@ -47,22 +44,30 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
             )
             return f"Paperless API error {exc.status_code}: {exc.detail}"
         except httpx.HTTPStatusError as exc:
+            api_exc = error_from_response(exc.response)
             logger.warning(
                 "tool_http_status_error tool=%s status=%s url=%s",
                 name,
-                exc.response.status_code,
+                api_exc.status_code,
                 exc.request.url,
             )
-            body = exc.response.text or exc.response.reason_phrase
-            return f"Paperless API error {exc.response.status_code}: {_truncate(body)}"
+            return f"Paperless API error {api_exc.status_code}: {api_exc.detail}"
         except httpx.RequestError as exc:
             logger.warning("tool_network_error tool=%s error=%s", name, exc)
             return f"Network error connecting to Paperless: {exc}"
         except PydanticValidationError as exc:
+            errors = exc.errors()
+            detail = (
+                errors[0].get("msg") or errors[0].get("type") or "unknown"
+                if errors
+                else "unknown"
+            )
             logger.warning(
                 "tool_validation_error tool=%s errors=%d", name, exc.error_count()
             )
-            return f"Response validation failed: {_truncate(str(exc))}"
+            return (
+                f"Response validation failed ({exc.error_count()} error(s)): {detail}"
+            )
 
     return wrapper  # type: ignore[return-value]
 

--- a/src/paperless_mcp/tools/_registry.py
+++ b/src/paperless_mcp/tools/_registry.py
@@ -29,6 +29,13 @@ F = TypeVar("F", bound=Callable[..., object])
 logger = logging.getLogger(__name__)
 
 
+_MAX_ERROR_BODY = 500
+
+
+def _truncate(text: str, max_len: int = _MAX_ERROR_BODY) -> str:
+    return text if len(text) <= max_len else text[:max_len] + "…"
+
+
 def _wrap_with_error_handling(name: str, func: F) -> F:
     @functools.wraps(func)
     async def wrapper(*args: object, **kwargs: object) -> object:
@@ -46,16 +53,16 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
                 exc.response.status_code,
                 exc.request.url,
             )
-            return (
-                f"Paperless API error {exc.response.status_code}: "
-                f"{exc.response.text or exc.response.reason_phrase}"
-            )
+            body = exc.response.text or exc.response.reason_phrase
+            return f"Paperless API error {exc.response.status_code}: {_truncate(body)}"
         except httpx.RequestError as exc:
             logger.warning("tool_network_error tool=%s error=%s", name, exc)
             return f"Network error connecting to Paperless: {exc}"
         except PydanticValidationError as exc:
-            logger.warning("tool_validation_error tool=%s msg=%s", name, exc)
-            return f"Response validation failed: {exc}"
+            logger.warning(
+                "tool_validation_error tool=%s errors=%d", name, exc.error_count()
+            )
+            return f"Response validation failed: {_truncate(str(exc))}"
 
     return wrapper  # type: ignore[return-value]
 

--- a/tests/unit/client/test_documents_write.py
+++ b/tests/unit/client/test_documents_write.py
@@ -118,3 +118,26 @@ async def test_delete_note(documents: DocumentsClient) -> None:
         )
         await documents.delete_note(1, 9)
     assert "id=9" in str(route.calls.last.request.url)
+
+
+@pytest.mark.asyncio
+async def test_delete_note_404_raises_paperless_api_error(
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    from paperless_mcp.client import PaperlessClient
+    from paperless_mcp.client._errors import PaperlessAPIError
+
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.delete("/api/documents/42/notes/").mock(
+            return_value=httpx.Response(
+                404, json={"detail": "No Note matches the given query."}
+            )
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            with pytest.raises(PaperlessAPIError) as exc_info:
+                await c.documents.delete_note(42, 99)
+        finally:
+            await c.aclose()
+    assert exc_info.value.status_code == 404

--- a/tests/unit/client/test_documents_write.py
+++ b/tests/unit/client/test_documents_write.py
@@ -135,9 +135,7 @@ async def test_delete_note_404_raises_paperless_api_error(
             )
         )
         c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
-        try:
-            with pytest.raises(PaperlessAPIError) as exc_info:
-                await c.documents.delete_note(42, 99)
-        finally:
-            await c.aclose()
+        with pytest.raises(PaperlessAPIError) as exc_info:
+            await c.documents.delete_note(42, 99)
+        await c.aclose()
     assert exc_info.value.status_code == 404

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -59,5 +59,5 @@ async def test_wrap_catches_pydantic_validation_error() -> None:
     result = await wrapped()
     assert isinstance(result, str)
     assert "Error occurred during tool execution" not in result
-    # Pydantic validation error output mentions the field or the type
-    assert "n" in result or "validation" in result.lower() or "int" in result.lower()
+    assert "validation" in result.lower()
+    assert "int" in result.lower()

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -22,3 +22,42 @@ def test_load_svg_data_uri(tmp_path: Path) -> None:
 def test_load_svg_missing(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
         load_svg_data_uri(tmp_path / "nope.svg")
+
+
+@pytest.mark.asyncio
+async def test_wrap_catches_httpx_status_error() -> None:
+    import httpx
+
+    from paperless_mcp.tools._registry import _wrap_with_error_handling
+
+    async def boom() -> object:
+        request = httpx.Request("DELETE", "http://paperless.test/api/x/")
+        response = httpx.Response(404, request=request)
+        raise httpx.HTTPStatusError("404", request=request, response=response)
+
+    wrapped = _wrap_with_error_handling("delete_document_note", boom)
+    result = await wrapped()
+    assert isinstance(result, str)
+    assert "Error occurred during tool execution" not in result
+    assert "404" in result or "not found" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_wrap_catches_pydantic_validation_error() -> None:
+    from pydantic import BaseModel
+
+    from paperless_mcp.tools._registry import _wrap_with_error_handling
+
+    class M(BaseModel):
+        n: int
+
+    async def boom() -> object:
+        M.model_validate({"n": "not-an-int"})
+        return None
+
+    wrapped = _wrap_with_error_handling("delete_document_note", boom)
+    result = await wrapped()
+    assert isinstance(result, str)
+    assert "Error occurred during tool execution" not in result
+    # Pydantic validation error output mentions the field or the type
+    assert "n" in result or "validation" in result.lower() or "int" in result.lower()

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -32,14 +32,14 @@ async def test_wrap_catches_httpx_status_error() -> None:
 
     async def boom() -> object:
         request = httpx.Request("DELETE", "http://paperless.test/api/x/")
-        response = httpx.Response(404, request=request)
+        response = httpx.Response(404, json={"detail": "Not found."}, request=request)
         raise httpx.HTTPStatusError("404", request=request, response=response)
 
     wrapped = _wrap_with_error_handling("delete_document_note", boom)
     result = await wrapped()
     assert isinstance(result, str)
-    assert "Error occurred during tool execution" not in result
-    assert "404" in result or "not found" in result.lower()
+    assert result.startswith("Paperless API error 404:")
+    assert "Not found" in result
 
 
 @pytest.mark.asyncio
@@ -58,6 +58,4 @@ async def test_wrap_catches_pydantic_validation_error() -> None:
     wrapped = _wrap_with_error_handling("delete_document_note", boom)
     result = await wrapped()
     assert isinstance(result, str)
-    assert "Error occurred during tool execution" not in result
-    assert "validation" in result.lower()
-    assert "int" in result.lower()
+    assert result.startswith("Response validation failed (1 error(s)):")


### PR DESCRIPTION
## Summary
- `_wrap_with_error_handling` now additionally catches `httpx.HTTPStatusError` and `pydantic.ValidationError`, so tools like `delete_document_note` return the specific Paperless status + detail instead of FastMCP's generic fallback.
- Exception order: `PaperlessAPIError` → `HTTPStatusError` → `RequestError` → `PydanticValidationError` — `CancelledError` is never caught.
- Regression tests added against `respx`.

## Test plan
- [ ] Wrapper unit tests cover `HTTPStatusError` and `ValidationError` paths
- [ ] Client test confirms `delete_note` raises `PaperlessAPIError` on 404

Closes #12