### PR TITLE
feat(config): add optional PAPERLESS_MCP_PAPERLESS_PUBLIC_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@
 # PAPERLESS_MCP_OIDC_JWT_SIGNING_KEY=<hex-string>
 
 # --- Domain (populate from your ProjectConfig) ---
+
+# --- Paperless ---
+PAPERLESS_MCP_PAPERLESS_URL=http://paperless:8000
+PAPERLESS_MCP_API_TOKEN=<your-token>
+# Optional: public Paperless UI URL for user-visible links (web_url, share_url).
+# Defaults to PAPERLESS_MCP_PAPERLESS_URL if unset.
+# PAPERLESS_MCP_PAPERLESS_PUBLIC_URL=https://docs.example.com

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
 
 | Variable | Default | Description |
 |---|---|---|
+| `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` | *(same as `PAPERLESS_MCP_PAPERLESS_URL`)* | Public-facing Paperless UI URL used to construct user-visible links (e.g. `web_url`, `share_url`). Defaults to the API URL when unset. |
 | `PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS` | `30` | Per-request HTTP timeout (seconds). |
 | `PAPERLESS_MCP_HTTP_RETRIES` | `2` | Retries (not counting the initial attempt) on 5xx/network errors. |
 | `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` | `300` | TTL of URLs issued by `create_download_link`. Clamped `[30, 3600]`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,10 +13,29 @@ All configuration is provided via environment variables with the `PAPERLESS_MCP_
 
 | Variable | Default | Description |
 |---|---|---|
+| `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` | *(same as `PAPERLESS_MCP_PAPERLESS_URL`)* | Public-facing Paperless UI URL. See [Public URL](#public-url) below. |
 | `PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS` | `30.0` | Per-request timeout (connect + read + write) |
 | `PAPERLESS_MCP_HTTP_RETRIES` | `2` | Retry count for idempotent requests on network errors or 5xx |
 | `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` | `300` | TTL for download URLs issued by `create_download_link` (clamped 30–3600) |
 | `PAPERLESS_MCP_DEFAULT_PAGE_SIZE` | `25` | Default page size for list tools (clamped 1–100) |
+
+## Public URL
+
+`PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` lets you specify a different base URL for
+user-visible links (e.g. the `web_url` field on documents and the `share_url`
+field on share links) than the internal API URL used by the server.
+
+This is useful when Paperless-NGX is reachable by the MCP server at an internal
+address (e.g. `http://paperless:8000`) but documents should link to a public
+hostname (e.g. `https://docs.example.com`).
+
+When unset, it defaults to `PAPERLESS_MCP_PAPERLESS_URL`.  Trailing slashes are
+stripped automatically, consistent with `PAPERLESS_MCP_PAPERLESS_URL`.
+
+```bash
+PAPERLESS_MCP_PAPERLESS_URL=http://paperless:8000        # internal API URL
+PAPERLESS_MCP_PAPERLESS_PUBLIC_URL=https://docs.example.com  # public UI URL
+```
 
 ## Example `.env`
 

--- a/src/paperless_mcp/_domain_config.py
+++ b/src/paperless_mcp/_domain_config.py
@@ -58,12 +58,14 @@ class DomainConfig(BaseSettings):
     @field_validator("paperless_public_url")
     @classmethod
     def _strip_public_trailing_slash(cls, value: str | None) -> str | None:
-        return value.rstrip("/") if value else value
+        if not value:
+            return None
+        return value.rstrip("/")
 
     @model_validator(mode="after")
     def _default_public_url(self) -> DomainConfig:
         if self.paperless_public_url is None:
-            object.__setattr__(self, "paperless_public_url", self.paperless_url)
+            self.paperless_public_url = self.paperless_url
         return self
 
 

--- a/src/paperless_mcp/_domain_config.py
+++ b/src/paperless_mcp/_domain_config.py
@@ -8,7 +8,7 @@ handles Paperless-specific secrets and complex validation via pydantic-settings.
 
 from __future__ import annotations
 
-from pydantic import Field, SecretStr, ValidationError, field_validator
+from pydantic import Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _ENV_PREFIX = "PAPERLESS_MCP_"
@@ -31,6 +31,9 @@ class DomainConfig(BaseSettings):
             the ``create_download_link`` tool.  Clamped ``[30, 3600]``.
         default_page_size: Default ``page_size`` parameter for list tools.
             Clamped ``[1, 100]``.
+        paperless_public_url: Optional public-facing Paperless UI URL used to
+            construct user-visible links (e.g. document ``web_url``, share-link
+            ``share_url``).  Defaults to ``paperless_url`` when unset.
     """
 
     model_config = SettingsConfigDict(
@@ -45,11 +48,23 @@ class DomainConfig(BaseSettings):
     http_retries: int = Field(default=2, ge=0, le=10)
     download_link_ttl_seconds: int = Field(default=300, ge=30, le=3600)
     default_page_size: int = Field(default=25, ge=1, le=100)
+    paperless_public_url: str | None = Field(default=None)
 
     @field_validator("paperless_url")
     @classmethod
     def _strip_trailing_slash(cls, value: str) -> str:
         return value.rstrip("/")
+
+    @field_validator("paperless_public_url")
+    @classmethod
+    def _strip_public_trailing_slash(cls, value: str | None) -> str | None:
+        return value.rstrip("/") if value else value
+
+    @model_validator(mode="after")
+    def _default_public_url(self) -> DomainConfig:
+        if self.paperless_public_url is None:
+            object.__setattr__(self, "paperless_public_url", self.paperless_url)
+        return self
 
 
 def load_domain_config() -> DomainConfig:

--- a/src/paperless_mcp/_domain_config.py
+++ b/src/paperless_mcp/_domain_config.py
@@ -68,6 +68,16 @@ class DomainConfig(BaseSettings):
             self.paperless_public_url = self.paperless_url
         return self
 
+    @property
+    def public_url(self) -> str:
+        """Public-facing Paperless URL, always set (falls back to ``paperless_url``).
+
+        ``_default_public_url`` ensures ``paperless_public_url`` is never ``None``
+        after validation; this property exposes that guarantee as a plain ``str``
+        so callers do not need a type-narrowing guard.
+        """
+        return self.paperless_public_url or self.paperless_url
+
 
 def load_domain_config() -> DomainConfig:
     """Load :class:`DomainConfig` from environment, raising ``ValueError``.

--- a/src/paperless_mcp/resources/__init__.py
+++ b/src/paperless_mcp/resources/__init__.py
@@ -46,5 +46,6 @@ def register_resources(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
+            public_url=cfg.paperless_public_url or cfg.paperless_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/resources/__init__.py
+++ b/src/paperless_mcp/resources/__init__.py
@@ -46,6 +46,6 @@ def register_resources(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
-            public_url=cfg.paperless_public_url or cfg.paperless_url,
+            public_url=cfg.public_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/resources/collections.py
+++ b/src/paperless_mcp/resources/collections.py
@@ -18,6 +18,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         """Return server configuration as JSON."""
         snapshot = {
             "paperless_url": client.http.base_url,
+            "paperless_public_url": ctx.public_url,
             "read_only": ctx.read_only,
             "default_page_size": ctx.default_page_size,
         }

--- a/src/paperless_mcp/server.py
+++ b/src/paperless_mcp/server.py
@@ -72,7 +72,7 @@ def make_server(
         client=_client,
         read_only=False,
         default_page_size=domain_cfg.default_page_size,
-        public_url=domain_cfg.paperless_public_url or domain_cfg.paperless_url,
+        public_url=domain_cfg.public_url,
     )
 
     @asynccontextmanager

--- a/src/paperless_mcp/server.py
+++ b/src/paperless_mcp/server.py
@@ -72,6 +72,7 @@ def make_server(
         client=_client,
         read_only=False,
         default_page_size=domain_cfg.default_page_size,
+        public_url=domain_cfg.paperless_public_url or domain_cfg.paperless_url,
     )
 
     @asynccontextmanager

--- a/src/paperless_mcp/tools/__init__.py
+++ b/src/paperless_mcp/tools/__init__.py
@@ -64,6 +64,6 @@ def register_tools(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
-            public_url=cfg.paperless_public_url or cfg.paperless_url,
+            public_url=cfg.public_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/tools/__init__.py
+++ b/src/paperless_mcp/tools/__init__.py
@@ -64,5 +64,6 @@ def register_tools(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
+            public_url=cfg.paperless_public_url or cfg.paperless_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/tools/_context.py
+++ b/src/paperless_mcp/tools/_context.py
@@ -17,9 +17,12 @@ class ToolContext:
         default_page_size: Default pagination window for list tools.
         artifact_store: Optional artifact store for download links; ``None``
             under stdio transport.
+        public_url: Public Paperless UI base URL.  Used to construct
+            user-visible links (set from ``DomainConfig.paperless_public_url``).
     """
 
     client: PaperlessClient
     read_only: bool
     default_page_size: int
     artifact_store: object | None = None
+    public_url: str = ""

--- a/src/paperless_mcp/tools/_context.py
+++ b/src/paperless_mcp/tools/_context.py
@@ -24,5 +24,5 @@ class ToolContext:
     client: PaperlessClient
     read_only: bool
     default_page_size: int
+    public_url: str
     artifact_store: object | None = None
-    public_url: str = ""

--- a/tests/unit/resources/test_collections.py
+++ b/tests/unit/resources/test_collections.py
@@ -39,7 +39,9 @@ def _uris(mcp: FastMCP) -> set[str]:
 
 def test_all_collection_uris_registered() -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     collections_mod.register(mcp, ctx)
     uris = _uris(mcp)
     assert "config://paperless" in uris
@@ -59,7 +61,9 @@ async def test_tags_resource_returns_json(monkeypatch: pytest.MonkeyPatch) -> No
     from fastmcp import Client
 
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     collections_mod.register(mcp, ctx)
     async with Client(mcp) as client:
         result = await client.read_resource("tags://paperless")

--- a/tests/unit/resources/test_documents.py
+++ b/tests/unit/resources/test_documents.py
@@ -32,7 +32,9 @@ def _templates(mcp: FastMCP) -> set[str]:
 
 def test_registers_templated_uris() -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     templates = _templates(mcp)
     expected = {

--- a/tests/unit/resources/test_tasks_resource.py
+++ b/tests/unit/resources/test_tasks_resource.py
@@ -13,7 +13,9 @@ def test_registers_tasks_uri() -> None:
     client = MagicMock()
     client.tasks.list = AsyncMock(return_value=[])
     mcp = FastMCP("test")
-    ctx = ToolContext(client=client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=client, read_only=False, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     uris = {str(r.uri) for r in asyncio.run(mcp.list_resources())}
     assert "tasks://paperless" in uris

--- a/tests/unit/test_domain_config.py
+++ b/tests/unit/test_domain_config.py
@@ -52,8 +52,6 @@ def test_trailing_slash_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_public_url_defaults_to_paperless_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
-    from paperless_mcp._domain_config import load_domain_config
-
     cfg = load_domain_config()
     assert cfg.paperless_url == "http://paperless.internal:8000"
     assert cfg.paperless_public_url == "http://paperless.internal:8000"
@@ -65,9 +63,17 @@ def test_public_url_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
         "PAPERLESS_MCP_PAPERLESS_PUBLIC_URL", "https://docs.example.com/"
     )
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
-    from paperless_mcp._domain_config import load_domain_config
-
     cfg = load_domain_config()
     assert cfg.paperless_url == "http://paperless.internal:8000"
     # Trailing slash stripped to match paperless_url behaviour
     assert cfg.paperless_public_url == "https://docs.example.com"
+
+
+def test_public_url_empty_string_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_PUBLIC_URL", "")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"

--- a/tests/unit/test_domain_config.py
+++ b/tests/unit/test_domain_config.py
@@ -77,3 +77,15 @@ def test_public_url_empty_string_treated_as_unset(
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
     cfg = load_domain_config()
     assert cfg.paperless_public_url == "http://paperless.internal:8000"
+
+
+def test_public_url_inherits_stripped_paperless_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000/")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    # Trailing slash stripped on paperless_url, then inherited.
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"
+    assert cfg.public_url == "http://paperless.internal:8000"

--- a/tests/unit/test_domain_config.py
+++ b/tests/unit/test_domain_config.py
@@ -47,3 +47,27 @@ def test_trailing_slash_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "abc")
     cfg = load_domain_config()
     assert cfg.paperless_url == "http://paperless:8000"
+
+
+def test_public_url_defaults_to_paperless_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    from paperless_mcp._domain_config import load_domain_config
+
+    cfg = load_domain_config()
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"
+
+
+def test_public_url_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv(
+        "PAPERLESS_MCP_PAPERLESS_PUBLIC_URL", "https://docs.example.com/"
+    )
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    from paperless_mcp._domain_config import load_domain_config
+
+    cfg = load_domain_config()
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    # Trailing slash stripped to match paperless_url behaviour
+    assert cfg.paperless_public_url == "https://docs.example.com"

--- a/tests/unit/tools/test_crud_resources.py
+++ b/tests/unit/tools/test_crud_resources.py
@@ -49,7 +49,9 @@ def _names(mcp: FastMCP) -> set[str]:
 )
 def test_read_only_registers_read_tools_only(module: Any, prefix: str) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=True, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     assert f"list_{prefix}s" in names
@@ -73,7 +75,9 @@ def test_all_tools_have_icons(module: Any, prefix: str) -> None:
     from paperless_mcp.tools._icons import ICON_REGISTRY
 
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     for name in names:
@@ -91,7 +95,9 @@ def test_all_tools_have_icons(module: Any, prefix: str) -> None:
 )
 def test_read_write_registers_all(module: Any, prefix: str) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     expected = {
@@ -108,7 +114,9 @@ def test_read_write_registers_all(module: Any, prefix: str) -> None:
 def test_custom_field_tool_descriptions_mention_select_options() -> None:
     """Regression test: docstrings document extra_data.select_options shape."""
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     custom_fields_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     for name in ("create_custom_field", "update_custom_field"):

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -41,7 +41,9 @@ def _registered_names(mcp: FastMCP) -> set[str]:
 
 def test_read_only_registers_read_tools(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     names = _registered_names(mcp)
     assert "list_documents" in names
@@ -63,7 +65,9 @@ def test_read_only_registers_read_tools(mock_client: Any) -> None:
 
 def test_read_write_registers_all(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     names = _registered_names(mcp)
     expected = {
@@ -88,7 +92,9 @@ def test_read_write_registers_all(mock_client: Any) -> None:
 
 def test_all_tools_have_icons(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     tools = asyncio.run(mcp.list_tools())
     for tool in tools:
@@ -97,7 +103,9 @@ def test_all_tools_have_icons(mock_client: Any) -> None:
 
 def test_list_and_search_expose_include_content(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     for name in ("list_documents", "search_documents"):

--- a/tests/unit/tools/test_downloads.py
+++ b/tests/unit/tools/test_downloads.py
@@ -44,6 +44,7 @@ def test_registers_with_artifact_store() -> None:
         client=_mock_client(),
         read_only=False,
         default_page_size=25,
+        public_url="",
         artifact_store=_mock_artifact_store(),
     )
     downloads_mod.register(mcp, ctx)
@@ -56,6 +57,7 @@ def test_skips_registration_without_artifact_store() -> None:
         client=_mock_client(),
         read_only=False,
         default_page_size=25,
+        public_url="",
         artifact_store=None,
     )
     downloads_mod.register(mcp, ctx)

--- a/tests/unit/tools/test_observability.py
+++ b/tests/unit/tools/test_observability.py
@@ -60,7 +60,10 @@ def test_observability_tools_register(module: Any, expected: set[str]) -> None:
     for read_only in (True, False):
         mcp = FastMCP("test")
         ctx = ToolContext(
-            client=_mock_client(), read_only=read_only, default_page_size=25
+            client=_mock_client(),
+            read_only=read_only,
+            default_page_size=25,
+            public_url="",
         )
         module.register(mcp, ctx)
         assert expected.issubset(_names(mcp))

--- a/tests/unit/tools/test_tasks.py
+++ b/tests/unit/tools/test_tasks.py
@@ -26,7 +26,9 @@ def mock_client() -> Any:
 
 def test_list_tasks_registered_with_pagination(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     assert "list_tasks" in tools
@@ -39,7 +41,9 @@ def test_list_tasks_registered_with_pagination(mock_client: Any) -> None:
 @pytest.mark.asyncio
 async def test_list_tasks_default_forwards_filter(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     mock_client.tasks.list.return_value = Paginated[Task].model_validate(
         {"count": 0, "results": []}


### PR DESCRIPTION
## Summary
- New optional env var `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL`. When unset, defaults to `PAPERLESS_MCP_PAPERLESS_URL`.
- Threaded through `ToolContext.public_url` so downstream phases (#7, #6) can construct user-visible URLs without re-reading config.
- `config://paperless` resource now includes `paperless_public_url` in its snapshot.
- No user-visible behaviour change on its own.

## Test plan
- [x] Config tests cover default-to-api-url and explicit-override (`test_public_url_defaults_to_paperless_url`, `test_public_url_can_be_overridden`)
- [x] Trailing-slash stripping on `paperless_public_url` is consistent with `paperless_url`
- [x] All 167 existing tests pass (1 skipped — integration requires live server)
- [x] 100% branch coverage on `_domain_config.py` and `tools/_context.py`
- [x] Docs updated: `.env.example`, `README.md`, `docs/configuration.md`

Closes #8