### PR TITLE
feat(documents): add web_url to Document responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,10 @@
 # PAPERLESS_MCP_OIDC_JWT_SIGNING_KEY=<hex-string>
 
 # --- Domain (populate from your ProjectConfig) ---
+
+# --- Paperless ---
+PAPERLESS_MCP_PAPERLESS_URL=http://paperless:8000
+PAPERLESS_MCP_API_TOKEN=<your-token>
+# Optional: public Paperless UI URL for user-visible links (web_url, share_url).
+# Defaults to PAPERLESS_MCP_PAPERLESS_URL if unset.
+# PAPERLESS_MCP_PAPERLESS_PUBLIC_URL=https://docs.example.com

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `add_document_note` | Add a note to a document |
 | `delete_document_note` | Delete a note from a document |
 
+`get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
 ### Tags
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ All settings come from environment variables with the `PAPERLESS_MCP_` prefix.
 
 | Variable | Default | Description |
 |---|---|---|
+| `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` | *(same as `PAPERLESS_MCP_PAPERLESS_URL`)* | Public-facing Paperless UI URL used to construct user-visible links (e.g. `web_url`, `share_url`). Defaults to the API URL when unset. |
 | `PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS` | `30` | Per-request HTTP timeout (seconds). |
 | `PAPERLESS_MCP_HTTP_RETRIES` | `2` | Retries (not counting the initial attempt) on 5xx/network errors. |
 | `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` | `300` | TTL of URLs issued by `create_download_link`. Clamped `[30, 3600]`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,10 +13,29 @@ All configuration is provided via environment variables with the `PAPERLESS_MCP_
 
 | Variable | Default | Description |
 |---|---|---|
+| `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` | *(same as `PAPERLESS_MCP_PAPERLESS_URL`)* | Public-facing Paperless UI URL. See [Public URL](#public-url) below. |
 | `PAPERLESS_MCP_HTTP_TIMEOUT_SECONDS` | `30.0` | Per-request timeout (connect + read + write) |
 | `PAPERLESS_MCP_HTTP_RETRIES` | `2` | Retry count for idempotent requests on network errors or 5xx |
 | `PAPERLESS_MCP_DOWNLOAD_LINK_TTL_SECONDS` | `300` | TTL for download URLs issued by `create_download_link` (clamped 30–3600) |
 | `PAPERLESS_MCP_DEFAULT_PAGE_SIZE` | `25` | Default page size for list tools (clamped 1–100) |
+
+## Public URL
+
+`PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` lets you specify a different base URL for
+user-visible links (e.g. the `web_url` field on documents and the `share_url`
+field on share links) than the internal API URL used by the server.
+
+This is useful when Paperless-NGX is reachable by the MCP server at an internal
+address (e.g. `http://paperless:8000`) but documents should link to a public
+hostname (e.g. `https://docs.example.com`).
+
+When unset, it defaults to `PAPERLESS_MCP_PAPERLESS_URL`.  Trailing slashes are
+stripped automatically, consistent with `PAPERLESS_MCP_PAPERLESS_URL`.
+
+```bash
+PAPERLESS_MCP_PAPERLESS_URL=http://paperless:8000        # internal API URL
+PAPERLESS_MCP_PAPERLESS_PUBLIC_URL=https://docs.example.com  # public UI URL
+```
 
 ## Example `.env`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -19,6 +19,8 @@ Paperless MCP exposes the following tools to MCP clients.
 | `get_document_history` | Retrieve audit log for a document |
 | `create_download_link` | Generate a time-limited download URL |
 
+`get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
 ## Tag tools
 
 | Tool | Description |

--- a/src/paperless_mcp/_domain_config.py
+++ b/src/paperless_mcp/_domain_config.py
@@ -8,7 +8,7 @@ handles Paperless-specific secrets and complex validation via pydantic-settings.
 
 from __future__ import annotations
 
-from pydantic import Field, SecretStr, ValidationError, field_validator
+from pydantic import Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _ENV_PREFIX = "PAPERLESS_MCP_"
@@ -31,6 +31,9 @@ class DomainConfig(BaseSettings):
             the ``create_download_link`` tool.  Clamped ``[30, 3600]``.
         default_page_size: Default ``page_size`` parameter for list tools.
             Clamped ``[1, 100]``.
+        paperless_public_url: Optional public-facing Paperless UI URL used to
+            construct user-visible links (e.g. document ``web_url``, share-link
+            ``share_url``).  Defaults to ``paperless_url`` when unset.
     """
 
     model_config = SettingsConfigDict(
@@ -45,11 +48,35 @@ class DomainConfig(BaseSettings):
     http_retries: int = Field(default=2, ge=0, le=10)
     download_link_ttl_seconds: int = Field(default=300, ge=30, le=3600)
     default_page_size: int = Field(default=25, ge=1, le=100)
+    paperless_public_url: str | None = Field(default=None)
 
     @field_validator("paperless_url")
     @classmethod
     def _strip_trailing_slash(cls, value: str) -> str:
         return value.rstrip("/")
+
+    @field_validator("paperless_public_url")
+    @classmethod
+    def _strip_public_trailing_slash(cls, value: str | None) -> str | None:
+        if not value:
+            return None
+        return value.rstrip("/")
+
+    @model_validator(mode="after")
+    def _default_public_url(self) -> DomainConfig:
+        if self.paperless_public_url is None:
+            self.paperless_public_url = self.paperless_url
+        return self
+
+    @property
+    def public_url(self) -> str:
+        """Public-facing Paperless URL, always set (falls back to ``paperless_url``).
+
+        ``_default_public_url`` ensures ``paperless_public_url`` is never ``None``
+        after validation; this property exposes that guarantee as a plain ``str``
+        so callers do not need a type-narrowing guard.
+        """
+        return self.paperless_public_url or self.paperless_url
 
 
 def load_domain_config() -> DomainConfig:

--- a/src/paperless_mcp/models/document.py
+++ b/src/paperless_mcp/models/document.py
@@ -45,6 +45,7 @@ class Document(BaseModel):
     notes: list[DocumentNote] = Field(default_factory=list)
     custom_fields: list[CustomFieldInstance] = Field(default_factory=list)
     page_count: int | None = None
+    web_url: str | None = None
 
 
 class DocumentPatch(BaseModel):

--- a/src/paperless_mcp/resources/__init__.py
+++ b/src/paperless_mcp/resources/__init__.py
@@ -46,5 +46,6 @@ def register_resources(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
+            public_url=cfg.public_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/resources/collections.py
+++ b/src/paperless_mcp/resources/collections.py
@@ -18,6 +18,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         """Return server configuration as JSON."""
         snapshot = {
             "paperless_url": client.http.base_url,
+            "paperless_public_url": ctx.public_url,
             "read_only": ctx.read_only,
             "default_page_size": ctx.default_page_size,
         }

--- a/src/paperless_mcp/server.py
+++ b/src/paperless_mcp/server.py
@@ -72,6 +72,7 @@ def make_server(
         client=_client,
         read_only=False,
         default_page_size=domain_cfg.default_page_size,
+        public_url=domain_cfg.public_url,
     )
 
     @asynccontextmanager

--- a/src/paperless_mcp/tools/__init__.py
+++ b/src/paperless_mcp/tools/__init__.py
@@ -64,5 +64,6 @@ def register_tools(
             client=client,
             read_only=read_only,
             default_page_size=cfg.default_page_size,
+            public_url=cfg.public_url,
         )
     _register_all(mcp, ctx)

--- a/src/paperless_mcp/tools/_context.py
+++ b/src/paperless_mcp/tools/_context.py
@@ -17,9 +17,12 @@ class ToolContext:
         default_page_size: Default pagination window for list tools.
         artifact_store: Optional artifact store for download links; ``None``
             under stdio transport.
+        public_url: Public Paperless UI base URL.  Used to construct
+            user-visible links (set from ``DomainConfig.paperless_public_url``).
     """
 
     client: PaperlessClient
     read_only: bool
     default_page_size: int
+    public_url: str
     artifact_store: object | None = None

--- a/src/paperless_mcp/tools/documents.py
+++ b/src/paperless_mcp/tools/documents.py
@@ -37,6 +37,11 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     client = ctx.client
     read_only = ctx.read_only
 
+    def _with_web_url(doc: Document) -> None:
+        """Populate *doc*'s ``web_url`` when a public URL is configured."""
+        if ctx.public_url:
+            doc.web_url = f"{ctx.public_url}/documents/{doc.id}/"
+
     @register_tool(mcp, "list_documents", read_only_mode=read_only)
     async def list_documents(
         page: Annotated[int, Field(ge=1)] = 1,
@@ -54,7 +59,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         By default, per-document OCR ``content`` is stripped to keep results
         small.  Pass ``include_content=True`` for the full text on each hit.
         """
-        return await client.documents.list(
+        result = await client.documents.list(
             page=page,
             page_size=page_size,
             ordering=ordering,
@@ -65,6 +70,9 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
             custom_field=custom_field,
             include_content=include_content,
         )
+        for doc in result.results:
+            _with_web_url(doc)
+        return result
 
     @register_tool(mcp, "search_documents", read_only_mode=read_only)
     async def search_documents(
@@ -80,18 +88,23 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         ``include_content=True`` to get full OCR text per hit.
         Use *more_like* for similarity search.
         """
-        return await client.documents.search(
+        result = await client.documents.search(
             query,
             page=page,
             page_size=page_size,
             more_like=more_like,
             include_content=include_content,
         )
+        for doc in result.results:
+            _with_web_url(doc)
+        return result
 
     @register_tool(mcp, "get_document", read_only_mode=read_only)
     async def get_document(document_id: int) -> Document:
         """Fetch one document by ID."""
-        return await client.documents.get(document_id)
+        doc = await client.documents.get(document_id)
+        _with_web_url(doc)
+        return doc
 
     @register_tool(mcp, "get_document_content", read_only_mode=read_only)
     async def get_document_content(document_id: int) -> str:
@@ -131,7 +144,9 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     @register_tool(mcp, "update_document", read_only_mode=read_only)
     async def update_document(document_id: int, patch: DocumentPatch) -> Document:
         """Patch selected fields on a document."""
-        return await client.documents.update(document_id, patch)
+        doc = await client.documents.update(document_id, patch)
+        _with_web_url(doc)
+        return doc
 
     @register_tool(mcp, "delete_document", read_only_mode=read_only)
     async def delete_document(document_id: int) -> None:

--- a/tests/unit/resources/test_collections.py
+++ b/tests/unit/resources/test_collections.py
@@ -39,7 +39,9 @@ def _uris(mcp: FastMCP) -> set[str]:
 
 def test_all_collection_uris_registered() -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     collections_mod.register(mcp, ctx)
     uris = _uris(mcp)
     assert "config://paperless" in uris
@@ -59,7 +61,9 @@ async def test_tags_resource_returns_json(monkeypatch: pytest.MonkeyPatch) -> No
     from fastmcp import Client
 
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     collections_mod.register(mcp, ctx)
     async with Client(mcp) as client:
         result = await client.read_resource("tags://paperless")

--- a/tests/unit/resources/test_documents.py
+++ b/tests/unit/resources/test_documents.py
@@ -32,7 +32,9 @@ def _templates(mcp: FastMCP) -> set[str]:
 
 def test_registers_templated_uris() -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     templates = _templates(mcp)
     expected = {

--- a/tests/unit/resources/test_tasks_resource.py
+++ b/tests/unit/resources/test_tasks_resource.py
@@ -13,7 +13,9 @@ def test_registers_tasks_uri() -> None:
     client = MagicMock()
     client.tasks.list = AsyncMock(return_value=[])
     mcp = FastMCP("test")
-    ctx = ToolContext(client=client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=client, read_only=False, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     uris = {str(r.uri) for r in asyncio.run(mcp.list_resources())}
     assert "tasks://paperless" in uris

--- a/tests/unit/test_domain_config.py
+++ b/tests/unit/test_domain_config.py
@@ -47,3 +47,45 @@ def test_trailing_slash_stripped(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "abc")
     cfg = load_domain_config()
     assert cfg.paperless_url == "http://paperless:8000"
+
+
+def test_public_url_defaults_to_paperless_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"
+
+
+def test_public_url_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv(
+        "PAPERLESS_MCP_PAPERLESS_PUBLIC_URL", "https://docs.example.com/"
+    )
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    # Trailing slash stripped to match paperless_url behaviour
+    assert cfg.paperless_public_url == "https://docs.example.com"
+
+
+def test_public_url_empty_string_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000")
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_PUBLIC_URL", "")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"
+
+
+def test_public_url_inherits_stripped_paperless_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAPERLESS_MCP_PAPERLESS_URL", "http://paperless.internal:8000/")
+    monkeypatch.setenv("PAPERLESS_MCP_API_TOKEN", "t")
+    cfg = load_domain_config()
+    # Trailing slash stripped on paperless_url, then inherited.
+    assert cfg.paperless_url == "http://paperless.internal:8000"
+    assert cfg.paperless_public_url == "http://paperless.internal:8000"
+    assert cfg.public_url == "http://paperless.internal:8000"

--- a/tests/unit/tools/test_crud_resources.py
+++ b/tests/unit/tools/test_crud_resources.py
@@ -49,7 +49,9 @@ def _names(mcp: FastMCP) -> set[str]:
 )
 def test_read_only_registers_read_tools_only(module: Any, prefix: str) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=True, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     assert f"list_{prefix}s" in names
@@ -73,7 +75,9 @@ def test_all_tools_have_icons(module: Any, prefix: str) -> None:
     from paperless_mcp.tools._icons import ICON_REGISTRY
 
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     for name in names:
@@ -91,7 +95,9 @@ def test_all_tools_have_icons(module: Any, prefix: str) -> None:
 )
 def test_read_write_registers_all(module: Any, prefix: str) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     module.register(mcp, ctx)
     names = _names(mcp)
     expected = {
@@ -108,7 +114,9 @@ def test_read_write_registers_all(module: Any, prefix: str) -> None:
 def test_custom_field_tool_descriptions_mention_select_options() -> None:
     """Regression test: docstrings document extra_data.select_options shape."""
     mcp = FastMCP("test")
-    ctx = ToolContext(client=_mock_client(), read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=_mock_client(), read_only=False, default_page_size=25, public_url=""
+    )
     custom_fields_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     for name in ("create_custom_field", "update_custom_field"):

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.document import Document
 from paperless_mcp.tools import documents as documents_mod
 from paperless_mcp.tools._context import ToolContext
 
@@ -112,3 +115,130 @@ def test_list_and_search_expose_include_content(mock_client: Any) -> None:
         schema = tools[name].parameters
         assert "include_content" in schema["properties"]
         assert schema["properties"]["include_content"].get("default") is False
+
+
+@pytest.mark.asyncio
+async def test_get_document_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+
+    mock_client.documents.get.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_document", {"document_id": 42})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_list_documents_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    page = Paginated[Document].model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "all": [42],
+            "results": [{"id": 42, "title": "X", "created": "2026-01-01T00:00:00Z"}],
+        }
+    )
+    mock_client.documents.list.return_value = page
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("list_documents", {})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0]["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_search_documents_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    page = Paginated[Document].model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "all": [99],
+            "results": [{"id": 99, "title": "Y", "created": "2026-01-01T00:00:00Z"}],
+        }
+    )
+    mock_client.documents.search.return_value = page
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("search_documents", {"query": "foo"})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0]["web_url"] == "https://docs.example.com/documents/99/"
+
+
+@pytest.mark.asyncio
+async def test_update_document_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=False,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.update.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool(
+            "update_document", {"document_id": 42, "patch": {"title": "Y"}}
+        )
+
+    data = result.structured_content
+    assert data is not None
+    assert data["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_web_url_none_when_public_url_empty(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="",
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.get.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_document", {"document_id": 42})
+
+    data = result.structured_content
+    assert data is not None
+    assert data.get("web_url") is None

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -41,7 +41,9 @@ def _registered_names(mcp: FastMCP) -> set[str]:
 
 def test_read_only_registers_read_tools(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     names = _registered_names(mcp)
     assert "list_documents" in names
@@ -63,7 +65,9 @@ def test_read_only_registers_read_tools(mock_client: Any) -> None:
 
 def test_read_write_registers_all(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     names = _registered_names(mcp)
     expected = {
@@ -88,7 +92,9 @@ def test_read_write_registers_all(mock_client: Any) -> None:
 
 def test_all_tools_have_icons(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=False, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     tools = asyncio.run(mcp.list_tools())
     for tool in tools:
@@ -97,7 +103,9 @@ def test_all_tools_have_icons(mock_client: Any) -> None:
 
 def test_list_and_search_expose_include_content(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     documents_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     for name in ("list_documents", "search_documents"):

--- a/tests/unit/tools/test_downloads.py
+++ b/tests/unit/tools/test_downloads.py
@@ -44,6 +44,7 @@ def test_registers_with_artifact_store() -> None:
         client=_mock_client(),
         read_only=False,
         default_page_size=25,
+        public_url="",
         artifact_store=_mock_artifact_store(),
     )
     downloads_mod.register(mcp, ctx)
@@ -56,6 +57,7 @@ def test_skips_registration_without_artifact_store() -> None:
         client=_mock_client(),
         read_only=False,
         default_page_size=25,
+        public_url="",
         artifact_store=None,
     )
     downloads_mod.register(mcp, ctx)

--- a/tests/unit/tools/test_observability.py
+++ b/tests/unit/tools/test_observability.py
@@ -60,7 +60,10 @@ def test_observability_tools_register(module: Any, expected: set[str]) -> None:
     for read_only in (True, False):
         mcp = FastMCP("test")
         ctx = ToolContext(
-            client=_mock_client(), read_only=read_only, default_page_size=25
+            client=_mock_client(),
+            read_only=read_only,
+            default_page_size=25,
+            public_url="",
         )
         module.register(mcp, ctx)
         assert expected.issubset(_names(mcp))

--- a/tests/unit/tools/test_tasks.py
+++ b/tests/unit/tools/test_tasks.py
@@ -26,7 +26,9 @@ def mock_client() -> Any:
 
 def test_list_tasks_registered_with_pagination(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
     assert "list_tasks" in tools
@@ -39,7 +41,9 @@ def test_list_tasks_registered_with_pagination(mock_client: Any) -> None:
 @pytest.mark.asyncio
 async def test_list_tasks_default_forwards_filter(mock_client: Any) -> None:
     mcp = FastMCP("test")
-    ctx = ToolContext(client=mock_client, read_only=True, default_page_size=25)
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
     tasks_mod.register(mcp, ctx)
     mock_client.tasks.list.return_value = Paginated[Task].model_validate(
         {"count": 0, "results": []}


### PR DESCRIPTION
## Summary
- `Document` model gains an optional `web_url` field.
- `get_document`, `list_documents`, `search_documents`, and `update_document` populate it from `ctx.public_url` (falls back to API URL via Phase 5's config).
- LLM clients can now surface a clickable "Open in Paperless" link.

## Depends on
- #20 (Phase 5: PAPERLESS_PUBLIC_URL config) — this PR's base branch. Will rebase onto `main` once #20 merges.

## Test plan
- [ ] web_url populated on get/list/search/update
- [ ] No web_url when no public URL configured
- [ ] Docs updated

Closes #7