### PR TITLE
fix: land web_url and share_url onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `get_storage_path` | Get a storage path by ID |
 | `list_saved_views` | List saved views |
 | `get_saved_view` | Get a saved view by ID |
-| `list_share_links` | List share links (includes `share_url`; uses `PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_URL`) |
-| `get_share_link` | Get a share link by ID (includes `share_url`; uses `PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_URL`) |
+| `list_share_links` | List share links (includes `share_url`; uses `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_MCP_PAPERLESS_URL`) |
+| `get_share_link` | Get a share link by ID (includes `share_url`; uses `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_MCP_PAPERLESS_URL`) |
 | `list_tasks` | List background tasks. Paginates (`page`, `page_size` up to 100). By default returns only unacknowledged tasks — pass `include_acknowledged=True` to include acknowledged tasks, or `acknowledged=True` to return only acknowledged ones. |
 | `get_task` | Get a task by ID |
 | `wait_for_task` | Wait until a task completes |

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `get_storage_path` | Get a storage path by ID |
 | `list_saved_views` | List saved views |
 | `get_saved_view` | Get a saved view by ID |
-| `list_share_links` | List share links |
-| `get_share_link` | Get a share link by ID |
+| `list_share_links` | List share links (includes `share_url`; uses `PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_URL`) |
+| `get_share_link` | Get a share link by ID (includes `share_url`; uses `PAPERLESS_PUBLIC_URL` if set, otherwise `PAPERLESS_URL`) |
 | `list_tasks` | List background tasks. Paginates (`page`, `page_size` up to 100). By default returns only unacknowledged tasks — pass `include_acknowledged=True` to include acknowledged tasks, or `acknowledged=True` to return only acknowledged ones. |
 | `get_task` | Get a task by ID |
 | `wait_for_task` | Wait until a task completes |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `add_document_note` | Add a note to a document |
 | `delete_document_note` | Delete a note from a document |
 
+`get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
 ### Tags
 
 | Tool | Description |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -74,6 +74,18 @@ The `extra_data` field shape depends on the custom field's `data_type`. Refer to
 
 Unknown shapes are rejected by Paperless with a 400 error.
 
+## Share link tools
+
+| Tool | Description |
+|---|---|
+| `list_share_links` | List share links (optionally filtered by document) |
+| `get_share_link` | Fetch a share link by ID |
+
+Both tools include a `share_url` field of the form `<PAPERLESS_PUBLIC_URL>/share/<slug>`.
+`PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` is used when set; otherwise it defaults to
+`PAPERLESS_MCP_PAPERLESS_URL` via the config layer (see `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL`
+in the README env-var table).
+
 ## Task tools
 
 | Tool | Description |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -19,6 +19,8 @@ Paperless MCP exposes the following tools to MCP clients.
 | `get_document_history` | Retrieve audit log for a document |
 | `create_download_link` | Generate a time-limited download URL |
 
+`get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
 ## Tag tools
 
 | Tool | Description |

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -81,7 +81,7 @@ Unknown shapes are rejected by Paperless with a 400 error.
 | `list_share_links` | List share links (optionally filtered by document) |
 | `get_share_link` | Fetch a share link by ID |
 
-Both tools include a `share_url` field of the form `<PAPERLESS_PUBLIC_URL>/share/<slug>`.
+Both tools include a `share_url` field of the form `<PAPERLESS_MCP_PAPERLESS_PUBLIC_URL>/share/<slug>`.
 `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` is used when set; otherwise it defaults to
 `PAPERLESS_MCP_PAPERLESS_URL` via the config layer (see `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL`
 in the README env-var table).

--- a/src/paperless_mcp/models/document.py
+++ b/src/paperless_mcp/models/document.py
@@ -45,6 +45,7 @@ class Document(BaseModel):
     notes: list[DocumentNote] = Field(default_factory=list)
     custom_fields: list[CustomFieldInstance] = Field(default_factory=list)
     page_count: int | None = None
+    web_url: str | None = None
 
 
 class DocumentPatch(BaseModel):

--- a/src/paperless_mcp/models/share_link.py
+++ b/src/paperless_mcp/models/share_link.py
@@ -21,3 +21,4 @@ class ShareLink(BaseModel):
     slug: str
     document: int
     file_version: ShareLinkFileVersion
+    share_url: str | None = None

--- a/src/paperless_mcp/tools/documents.py
+++ b/src/paperless_mcp/tools/documents.py
@@ -37,6 +37,11 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     client = ctx.client
     read_only = ctx.read_only
 
+    def _with_web_url(doc: Document) -> None:
+        """Populate *doc*'s ``web_url`` when a public URL is configured."""
+        if ctx.public_url:
+            doc.web_url = f"{ctx.public_url}/documents/{doc.id}/"
+
     @register_tool(mcp, "list_documents", read_only_mode=read_only)
     async def list_documents(
         page: Annotated[int, Field(ge=1)] = 1,
@@ -54,7 +59,7 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         By default, per-document OCR ``content`` is stripped to keep results
         small.  Pass ``include_content=True`` for the full text on each hit.
         """
-        return await client.documents.list(
+        result = await client.documents.list(
             page=page,
             page_size=page_size,
             ordering=ordering,
@@ -65,6 +70,9 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
             custom_field=custom_field,
             include_content=include_content,
         )
+        for doc in result.results:
+            _with_web_url(doc)
+        return result
 
     @register_tool(mcp, "search_documents", read_only_mode=read_only)
     async def search_documents(
@@ -80,18 +88,23 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         ``include_content=True`` to get full OCR text per hit.
         Use *more_like* for similarity search.
         """
-        return await client.documents.search(
+        result = await client.documents.search(
             query,
             page=page,
             page_size=page_size,
             more_like=more_like,
             include_content=include_content,
         )
+        for doc in result.results:
+            _with_web_url(doc)
+        return result
 
     @register_tool(mcp, "get_document", read_only_mode=read_only)
     async def get_document(document_id: int) -> Document:
         """Fetch one document by ID."""
-        return await client.documents.get(document_id)
+        doc = await client.documents.get(document_id)
+        _with_web_url(doc)
+        return doc
 
     @register_tool(mcp, "get_document_content", read_only_mode=read_only)
     async def get_document_content(document_id: int) -> str:
@@ -131,7 +144,9 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     @register_tool(mcp, "update_document", read_only_mode=read_only)
     async def update_document(document_id: int, patch: DocumentPatch) -> Document:
         """Patch selected fields on a document."""
-        return await client.documents.update(document_id, patch)
+        doc = await client.documents.update(document_id, patch)
+        _with_web_url(doc)
+        return doc
 
     @register_tool(mcp, "delete_document", read_only_mode=read_only)
     async def delete_document(document_id: int) -> None:

--- a/src/paperless_mcp/tools/share_links.py
+++ b/src/paperless_mcp/tools/share_links.py
@@ -23,6 +23,11 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     client = ctx.client
     read_only = ctx.read_only
 
+    def _with_share_url(link: ShareLink) -> None:
+        """Populate *link*'s ``share_url`` when a public URL is configured."""
+        if ctx.public_url:
+            link.share_url = f"{ctx.public_url}/share/{link.slug}"
+
     @register_tool(mcp, "list_share_links", read_only_mode=read_only)
     async def list_share_links(
         page: Annotated[int, Field(ge=1)] = 1,
@@ -30,11 +35,16 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         document_id: int | None = None,
     ) -> Paginated[ShareLink]:
         """List share links (optionally filtered by document)."""
-        return await client.share_links.list(
+        result = await client.share_links.list(
             page=page, page_size=page_size, document_id=document_id
         )
+        for link in result.results:
+            _with_share_url(link)
+        return result
 
     @register_tool(mcp, "get_share_link", read_only_mode=read_only)
     async def get_share_link(share_link_id: int) -> ShareLink:
         """Fetch a share link by ID."""
-        return await client.share_links.get(share_link_id)
+        link = await client.share_links.get(share_link_id)
+        _with_share_url(link)
+        return link

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from fastmcp import FastMCP
+from fastmcp import Client, FastMCP
 
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.document import Document
 from paperless_mcp.tools import documents as documents_mod
 from paperless_mcp.tools._context import ToolContext
 
@@ -112,3 +115,130 @@ def test_list_and_search_expose_include_content(mock_client: Any) -> None:
         schema = tools[name].parameters
         assert "include_content" in schema["properties"]
         assert schema["properties"]["include_content"].get("default") is False
+
+
+@pytest.mark.asyncio
+async def test_get_document_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+
+    mock_client.documents.get.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_document", {"document_id": 42})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_list_documents_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    page = Paginated[Document].model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "all": [42],
+            "results": [{"id": 42, "title": "X", "created": "2026-01-01T00:00:00Z"}],
+        }
+    )
+    mock_client.documents.list.return_value = page
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("list_documents", {})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0]["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_search_documents_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    page = Paginated[Document].model_validate(
+        {
+            "count": 1,
+            "next": None,
+            "previous": None,
+            "all": [99],
+            "results": [{"id": 99, "title": "Y", "created": "2026-01-01T00:00:00Z"}],
+        }
+    )
+    mock_client.documents.search.return_value = page
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("search_documents", {"query": "foo"})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0]["web_url"] == "https://docs.example.com/documents/99/"
+
+
+@pytest.mark.asyncio
+async def test_update_document_populates_web_url(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=False,
+        default_page_size=25,
+        public_url="https://docs.example.com",
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.update.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool(
+            "update_document", {"document_id": 42, "patch": {"title": "Y"}}
+        )
+
+    data = result.structured_content
+    assert data is not None
+    assert data["web_url"] == "https://docs.example.com/documents/42/"
+
+
+@pytest.mark.asyncio
+async def test_web_url_none_when_public_url_empty(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client,
+        read_only=True,
+        default_page_size=25,
+        public_url="",
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.get.return_value = Document(
+        id=42, title="X", created=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_document", {"document_id": 42})
+
+    data = result.structured_content
+    assert data is not None
+    assert data.get("web_url") is None

--- a/tests/unit/tools/test_share_links.py
+++ b/tests/unit/tools/test_share_links.py
@@ -1,0 +1,144 @@
+"""Tool-layer tests for share-link tools with share_url."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from paperless_mcp.models.common import Paginated
+from paperless_mcp.models.share_link import ShareLink, ShareLinkFileVersion
+from paperless_mcp.tools import share_links as sl_mod
+from paperless_mcp.tools._context import ToolContext
+
+
+def _link() -> ShareLink:
+    return ShareLink(
+        id=1,
+        created=datetime(2026, 1, 1, tzinfo=UTC),
+        slug="abc123",
+        document=42,
+        file_version=ShareLinkFileVersion.ARCHIVE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_share_link_populates_share_url() -> None:
+    client = MagicMock()
+    client.share_links.get = AsyncMock(return_value=_link())
+    mcp = FastMCP("t")
+    sl_mod.register(
+        mcp,
+        ToolContext(
+            client=client,
+            read_only=True,
+            default_page_size=25,
+            public_url="https://docs.example.com",
+        ),
+    )
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_share_link", {"share_link_id": 1})
+    data = result.structured_content
+    assert data is not None
+    assert data["share_url"] == "https://docs.example.com/share/abc123"
+
+
+@pytest.mark.asyncio
+async def test_list_share_links_populates_share_url() -> None:
+    client = MagicMock()
+    client.share_links.list = AsyncMock(
+        return_value=Paginated[ShareLink].model_validate(
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "all": [1],
+                "results": [
+                    {
+                        "id": 1,
+                        "created": "2026-01-01T00:00:00Z",
+                        "slug": "abc123",
+                        "document": 42,
+                        "file_version": "archive",
+                    }
+                ],
+            }
+        )
+    )
+    mcp = FastMCP("t")
+    sl_mod.register(
+        mcp,
+        ToolContext(
+            client=client,
+            read_only=True,
+            default_page_size=25,
+            public_url="https://docs.example.com",
+        ),
+    )
+    async with Client(mcp) as c:
+        result = await c.call_tool("list_share_links", {})
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0]["share_url"] == "https://docs.example.com/share/abc123"
+
+
+@pytest.mark.asyncio
+async def test_get_share_url_is_none_when_public_url_empty() -> None:
+    client = MagicMock()
+    client.share_links.get = AsyncMock(return_value=_link())
+    mcp = FastMCP("t")
+    sl_mod.register(
+        mcp,
+        ToolContext(
+            client=client,
+            read_only=True,
+            default_page_size=25,
+            public_url="",
+        ),
+    )
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_share_link", {"share_link_id": 1})
+    data = result.structured_content
+    assert data is not None
+    assert data.get("share_url") is None
+
+
+@pytest.mark.asyncio
+async def test_list_share_url_is_none_when_public_url_empty() -> None:
+    client = MagicMock()
+    client.share_links.list = AsyncMock(
+        return_value=Paginated[ShareLink].model_validate(
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "all": [1],
+                "results": [
+                    {
+                        "id": 1,
+                        "created": "2026-01-01T00:00:00Z",
+                        "slug": "abc123",
+                        "document": 42,
+                        "file_version": "archive",
+                    }
+                ],
+            }
+        )
+    )
+    mcp = FastMCP("t")
+    sl_mod.register(
+        mcp,
+        ToolContext(
+            client=client,
+            read_only=True,
+            default_page_size=25,
+            public_url="",
+        ),
+    )
+    async with Client(mcp) as c:
+        result = await c.call_tool("list_share_links", {})
+    data = result.structured_content
+    assert data is not None
+    assert data["results"][0].get("share_url") is None


### PR DESCRIPTION
## Summary

PRs #21 (`web_url` on Documents) and #22 (`share_url` on ShareLinks) auto-merged into their stacked base branch `feat/public-paperless-url` instead of `main`, so the commits never reached `main`. This PR re-lands both by cherry-picking the squash-merge commits from the stacked branch onto `main`.

- `3da3bdb` = contents of #21 (closes #7)
- `ca470a1` = contents of #22 (closes #6)

Both were already reviewed and approved in their original PRs; gates still green locally (191 passed, ruff + mypy clean).

## Test plan
- [x] `uv run pytest -x -q` — 191 passed, 1 skipped (integration)
- [x] `uv run ruff check .` + `ruff format --check` clean
- [x] `uv run mypy src/ tests/` clean

Closes #6, closes #7