### PR TITLE
feat(paginated): drop all_ids from Paginated[T] responses

### DIFF
--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -68,7 +68,6 @@ class TasksClient:
                 "count": total,
                 "next": next_marker,
                 "previous": previous_marker,
-                "all": [t.id for t in all_tasks],
                 "results": [t.model_dump() for t in all_tasks[start:end]],
             }
         )

--- a/src/paperless_mcp/models/common.py
+++ b/src/paperless_mcp/models/common.py
@@ -11,11 +11,11 @@ T = TypeVar("T")
 
 
 class Paginated(BaseModel, Generic[T]):
-    model_config = ConfigDict(extra="allow")
+    # extra="ignore" drops Paperless's upstream ``all: [...]`` id array (see #25).
+    model_config = ConfigDict(extra="ignore")
     count: int
     next: str | None = None
     previous: str | None = None
-    all_ids: list[int] | None = Field(None, alias="all")
     results: list[T] = Field(default_factory=list)
 
 

--- a/tests/unit/models/test_common.py
+++ b/tests/unit/models/test_common.py
@@ -40,6 +40,24 @@ def test_paginated_parses_results() -> None:
     assert page.results[0].extra == "hi"  # type: ignore[attr-defined]
 
 
+def test_paginated_drops_all_ids_from_upstream() -> None:
+    page = Paginated[_Item].model_validate(
+        {
+            "count": 3,
+            "next": None,
+            "previous": None,
+            "all": [1, 2, 3, 4, 5],
+            "results": [{"id": 1}, {"id": 2}, {"id": 3}],
+        }
+    )
+    dumped = page.model_dump()
+    assert "all" not in dumped
+    assert "all_ids" not in dumped
+    assert not hasattr(page, "all_ids")
+    assert page.count == 3
+    assert [r.id for r in page.results] == [1, 2, 3]
+
+
 def test_bulk_edit_operation_enum() -> None:
     assert BulkEditOperation("set_correspondent") == BulkEditOperation.SET_CORRESPONDENT
     with pytest.raises(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary
- Paperless returns an `all: [...]` array of every matching id on paginated endpoints (every list tool/resource).  LLM callers can't use it; it scales linearly with the data and costs ~10 kB per call on real corpora.
- Switch `Paginated[T]` from `extra="allow"` to `extra="ignore"` and drop the `all_ids` field entirely — any future upstream additions also get silently discarded.
- Removes the now-redundant manual `"all": [t.id for t in all_tasks]` population in #16's `list_tasks` client-side paginator.

## Test plan
- [x] New model test asserts `all` is stripped on `model_dump()`
- [x] Existing `Paginated` tests still pass — other fields (`count`, `next`, `previous`, `results`) unchanged
- [x] `uv run pytest -x -q`: 192 passed, 1 skipped
- [x] `ruff check/format` + `mypy src/ tests/` clean

Closes #25