### PR TITLE
fix(tasks): populate next/previous page markers in list_tasks

### DIFF
--- a/src/paperless_mcp/client/tasks.py
+++ b/src/paperless_mcp/client/tasks.py
@@ -60,11 +60,14 @@ class TasksClient:
         all_tasks = [Task.model_validate(item) for item in body]
         start = (page - 1) * page_size
         end = start + page_size
+        total = len(all_tasks)
+        next_marker = f"page={page + 1}" if end < total else None
+        previous_marker = f"page={page - 1}" if page > 1 else None
         return Paginated[Task].model_validate(
             {
-                "count": len(all_tasks),
-                "next": None,
-                "previous": None,
+                "count": total,
+                "next": next_marker,
+                "previous": previous_marker,
                 "all": [t.id for t in all_tasks],
                 "results": [t.model_dump() for t in all_tasks[start:end]],
             }

--- a/tests/unit/client/test_tasks.py
+++ b/tests/unit/client/test_tasks.py
@@ -140,3 +140,77 @@ async def test_list_tasks_acknowledged_none_sends_no_filter(
     assert route.called
     call = route.calls[0].request
     assert "acknowledged" not in call.url.params
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_next_previous_indicate_pages(
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    # 30 tasks, page_size=10 → three pages total.
+    bare = [
+        {
+            "id": i,
+            "task_id": f"uuid-{i}",
+            "status": "SUCCESS",
+            "acknowledged": False,
+            "type": "file",
+            "task_file_name": f"doc{i}.pdf",
+            "date_created": "2026-01-01T00:00:00Z",
+        }
+        for i in range(1, 31)
+    ]
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=bare))
+        client = PaperlessClient(
+            base_url=paperless_base_url, api_token=paperless_api_token
+        )
+        try:
+            page1 = await client.tasks.list(page=1, page_size=10)
+            page2 = await client.tasks.list(page=2, page_size=10)
+            page3 = await client.tasks.list(page=3, page_size=10)
+        finally:
+            await client.aclose()
+
+    # First page: no previous, next present.
+    assert page1.previous is None
+    assert page1.next == "page=2"
+
+    # Middle page: both set.
+    assert page2.previous == "page=1"
+    assert page2.next == "page=3"
+
+    # Last page: previous set, next None.
+    assert page3.previous == "page=2"
+    assert page3.next is None
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_next_previous_single_page(
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    # Fewer tasks than page_size → no next or previous.
+    bare = [
+        {
+            "id": 1,
+            "task_id": "uuid-1",
+            "status": "SUCCESS",
+            "acknowledged": False,
+            "type": "file",
+            "task_file_name": "a.pdf",
+            "date_created": "2026-01-01T00:00:00Z",
+        }
+    ]
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/tasks/").mock(return_value=httpx.Response(200, json=bare))
+        client = PaperlessClient(
+            base_url=paperless_base_url, api_token=paperless_api_token
+        )
+        try:
+            page = await client.tasks.list(page=1, page_size=25)
+        finally:
+            await client.aclose()
+
+    assert page.previous is None
+    assert page.next is None


### PR DESCRIPTION
## Summary
- Compute `next`/`previous` from the client-side page math rather than hardcoding both to `None`.  Callers can now detect "last page" without ceil-math.
- Markers are simple strings (`"page=2"`, etc.) matching the tool parameter name; the `Paginated[T]` schema is unchanged.
- The `all_ids` concern from #24 is addressed separately in #27 (drops the field repo-wide); this PR focuses on the list_tasks-specific pagination indicator.

## Test plan
- [x] New: three-page walk asserts `next`/`previous` transitions on first, middle, last page
- [x] New: single-page response shows both as `None`
- [x] Existing tests still pass — acknowledged filter, query params, page/page_size not forwarded to server
- [x] `uv run pytest -x -q`: 193 passed, 1 skipped
- [x] `ruff` + `mypy` clean

Closes #24