### PR TITLE
fix(history): redact OCR content from create-event changes

### DIFF
--- a/src/paperless_mcp/models/document.py
+++ b/src/paperless_mcp/models/document.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from paperless_mcp.models._compat import UserId, Username
+
+_CONTENT_REDACTED_MARKER = "<content redacted — use get_document_content>"
 
 
 class CustomFieldInstance(BaseModel):
@@ -83,6 +85,21 @@ class DocumentHistoryEntry(BaseModel):
     timestamp: datetime
     action: str
     actor: Username = None
+    changes: dict[str, Any] | None = None
+
+    @field_validator("changes")
+    @classmethod
+    def _redact_content(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        # Redact OCR blobs from changes.content; preserve None/"None" lifecycle markers.
+        if not value or "content" not in value:
+            return value
+        original = value["content"]
+        if isinstance(original, list) and len(original) == 2:
+            redacted = [
+                v if v in (None, "None") else _CONTENT_REDACTED_MARKER for v in original
+            ]
+            return {**value, "content": redacted}
+        return {**value, "content": _CONTENT_REDACTED_MARKER}
 
 
 class DocumentSuggestions(BaseModel):

--- a/tests/unit/models/test_document.py
+++ b/tests/unit/models/test_document.py
@@ -139,6 +139,97 @@ def test_username_rejects_dict_without_username_key() -> None:
         )
 
 
+def test_document_history_entry_redacts_content_on_create() -> None:
+    # Create events carry ["None", "<blob>"] — keep the marker, redact the blob.
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "create",
+            "actor": None,
+            "changes": {
+                "content": ["None", "A" * 50_000],
+                "title": ["None", "Invoice"],
+            },
+        }
+    )
+    assert entry.changes is not None
+    content_change = entry.changes["content"]
+    assert content_change[0] == "None"
+    assert "A" * 50_000 not in content_change[1]
+    assert "redacted" in content_change[1].lower()
+    assert entry.changes["title"] == ["None", "Invoice"]
+
+
+def test_document_history_entry_redacts_both_sides_on_modify() -> None:
+    # Modify events carry ["<old>", "<new>"] — both can be 50+ kB, redact both.
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "modify",
+            "actor": "peter",
+            "changes": {"content": ["B" * 50_000, "A" * 50_000]},
+        }
+    )
+    assert entry.changes is not None
+    content_change = entry.changes["content"]
+    assert "B" * 50_000 not in content_change[0]
+    assert "A" * 50_000 not in content_change[1]
+    assert "redacted" in content_change[0].lower()
+    assert "redacted" in content_change[1].lower()
+
+
+def test_document_history_entry_preserves_none_on_delete() -> None:
+    # Delete-style events carry ["<old>", None] — keep the None terminator.
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "delete",
+            "actor": "peter",
+            "changes": {"content": ["C" * 50_000, None]},
+        }
+    )
+    assert entry.changes is not None
+    content_change = entry.changes["content"]
+    assert content_change[1] is None
+    assert "C" * 50_000 not in content_change[0]
+    assert "redacted" in content_change[0].lower()
+
+
+def test_document_history_entry_redacts_non_list_content() -> None:
+    # Defensive: if Paperless sends content as a scalar, redact wholesale.
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "modify",
+            "actor": "peter",
+            "changes": {"content": "A" * 50_000},
+        }
+    )
+    assert entry.changes is not None
+    assert "A" * 50_000 not in entry.changes["content"]
+    assert "redacted" in entry.changes["content"].lower()
+
+
+def test_document_history_entry_no_changes_field() -> None:
+    """Entries without a ``changes`` dict still parse fine."""
+    entry = DocumentHistoryEntry.model_validate(
+        {"timestamp": "2026-04-23T10:00:00Z", "action": "modify", "actor": "peter"}
+    )
+    assert entry.changes is None
+
+
+def test_document_history_entry_changes_without_content_unchanged() -> None:
+    entry = DocumentHistoryEntry.model_validate(
+        {
+            "timestamp": "2026-04-23T10:00:00Z",
+            "action": "modify",
+            "actor": "peter",
+            "changes": {"title": ["Old", "New"]},
+        }
+    )
+    assert entry.changes == {"title": ["Old", "New"]}
+
+
 def test_document_suggestions_accepts_empty_lists() -> None:
     s = DocumentSuggestions.model_validate(
         {"tags": [], "correspondents": [], "document_types": [], "dates": []}


### PR DESCRIPTION
## Summary
- Paperless's simple_history dump records the full OCR text as the after-value of `changes.content` on document creation.  For real corpora `get_document_history` routinely returns 50+ kB per document.
- `DocumentHistoryEntry.changes` now goes through a field validator that replaces the content entry with a short redaction marker, preserving the 2-element change-tuple shape so the audit fact "content was set" is retained.
- Callers who need the text still have `get_document_content`; no client-side behaviour depends on the raw OCR blob appearing in history.

## Test plan
- [x] New: create event with 50 k content is redacted, sibling changes (e.g. title) untouched
- [x] New: entries without `changes` parse unchanged
- [x] New: `changes` that don't contain `content` are passed through verbatim
- [x] `uv run pytest -x -q`: 194 passed, 1 skipped
- [x] `ruff` + `mypy` clean

Closes #26