### PR TITLE
Strip heavy fields from list/search responses and add include_content to get/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 
 | Tool | Description |
 |---|---|
-| `list_documents` | List documents with optional filtering; OCR `content` stripped by default — pass `include_content=True` for full text |
-| `search_documents` | Full-text search across documents; OCR `content` stripped by default — pass `include_content=True` for full text |
-| `get_document` | Retrieve a document by ID |
+| `list_documents` | List documents with optional filtering; OCR `content` stripped by default (`include_content=True` for full text). `notes[].note` and `custom_fields[].value` are always stripped on listings — use single-document endpoints to fetch them. |
+| `search_documents` | Full-text search across documents; OCR `content` stripped by default (`include_content=True` for full text). `notes[].note` and `custom_fields[].value` are always stripped on search hits. |
+| `get_document` | Retrieve a document by ID; OCR `content` stripped by default (`include_content=True` for full text) |
 | `get_document_content` | Get the extracted text content of a document |
 | `get_document_thumbnail` | Get the thumbnail image of a document |
 | `get_document_metadata` | Get metadata (original filename, checksums, etc.) |
 | `get_document_notes` | List notes attached to a document |
 | `get_document_history` | Get the audit history of a document |
 | `get_document_suggestions` | Get AI-generated tag/correspondent/type suggestions |
-| `update_document` | Update document fields (title, tags, correspondent, etc.) |
+| `update_document` | Update document fields (title, tags, correspondent, etc.); response OCR `content` stripped by default (`include_content=True` to retain) |
 | `delete_document` | Delete a document |
 | `upload_document` | Upload a new document for processing |
 | `bulk_edit_documents` | Apply a bulk operation to multiple documents |
@@ -149,6 +149,8 @@ The following variables are inherited unchanged from [`fastmcp-server-template`]
 | `delete_document_note` | Delete a note from a document |
 
 `get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
+Paginated tools return `next`/`previous` as bare `page=N` markers (never full URLs) — callers pass `page=N` explicitly when walking pages. `None` means no further page.
 
 ### Tags
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,5 +48,5 @@ PAPERLESS_MCP_DEFAULT_PAGE_SIZE=50
 
 ## Log level
 
-Set `FASTMCP_LOG_LEVEL` to `DEBUG`, `INFO`, `WARNING`, or `ERROR`.  
+Set `FASTMCP_LOG_LEVEL` to `DEBUG`, `INFO`, `WARNING`, or `ERROR`.
 Pass `-v` / `--verbose` to the CLI to enable `DEBUG` automatically.

--- a/docs/superpowers/plans/2026-04-23-paperless-mcp.md
+++ b/docs/superpowers/plans/2026-04-23-paperless-mcp.md
@@ -7781,11 +7781,3 @@ Plan complete and saved to `docs/superpowers/plans/2026-04-23-paperless-mcp.md`.
 **2. Inline Execution** — run tasks in the current session with checkpoints. Useful for Phase A (scaffold verification) and the upstream-issue tasks (B1, C4, G1, J1) where human judgement is involved.
 
 Which approach?
-
-
-
-
-
-
-
-

--- a/docs/superpowers/specs/2026-04-23-paperless-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-23-paperless-mcp-design.md
@@ -154,11 +154,11 @@ Read-only tools always registered; writable tools skipped when
 `PAPERLESS_MCP_READ_ONLY=true`.
 
 ### Documents
-- `list_documents(page=1, page_size=25, ordering=None, tags=None, correspondent=None, document_type=None, storage_path=None, custom_field=None) -> Paginated[Document]`
-- `search_documents(query, page=1, page_size=25, more_like=None) -> Paginated[Document]`
-- `get_document(id) -> Document`
+- `list_documents(page=1, page_size=25, ordering=None, tags=None, correspondent=None, document_type=None, storage_path=None, custom_field=None, include_content=False) -> Paginated[Document]` — OCR `content` stripped by default; `notes[].note` and `custom_fields[].value` always stripped (see #30)
+- `search_documents(query, page=1, page_size=25, more_like=None, include_content=False) -> Paginated[Document]` — same stripping as `list_documents`
+- `get_document(id, include_content=False) -> Document` — OCR `content` stripped by default (#31); opt in for full text or use `get_document_content`
 - `upload_document(filename, content_base64, title=None, correspondent=None, document_type=None, tags=None, created=None, archive_serial_number=None, custom_fields=None) -> UploadTaskAcknowledgement`
-- `update_document(id, patch: DocumentPatch) -> Document`
+- `update_document(id, patch: DocumentPatch, include_content=False) -> Document` — response OCR `content` stripped by default
 - `delete_document(id) -> None`
 - `bulk_edit_documents(document_ids, method, parameters) -> BulkEditResult`
 - `get_document_content(id) -> str` — OCR'd plain text
@@ -286,7 +286,7 @@ Masking lives in `_http.py` log sanitizer. Candidate for upstream (issue #8).
   `DocumentPatch`, `TagCreate`, `TagPatch` — unknown fields are bugs.
 - Enums: `CustomFieldDataType`, `TaskStatus`, `BulkEditOperation`,
   `ShareLinkFileVersion`.
-- `Paginated[T]`: `count`, `next`, `previous`, `all` (IDs), `results: list[T]`.
+- `Paginated[T]`: `count`, `next`, `previous`, `results: list[T]`. The upstream `all: [...]` id array is dropped (#25). `next`/`previous` are normalised to bare `page=N` markers (or `None`) regardless of whether Paperless returns a full URL or a client-paginated endpoint emits the marker directly — the internal Paperless hostname never leaks into MCP responses (#32).
 
 ### Instructions block
 Built via pvl-core `build_instructions()`. Domain description from

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -6,9 +6,9 @@ Paperless MCP exposes the following tools to MCP clients.
 
 | Tool | Description |
 |---|---|
-| `list_documents` | List documents with optional filters; OCR `content` stripped by default (`include_content=True` to opt in) |
-| `search_documents` | Full-text and filtered document search; OCR `content` stripped by default (`include_content=True` to opt in) |
-| `get_document` | Retrieve document metadata by ID |
+| `list_documents` | List documents with optional filters; OCR `content` stripped by default (`include_content=True` to opt in). `notes[].note` and `custom_fields[].value` are always stripped — fetch them via single-document endpoints. |
+| `search_documents` | Full-text and filtered document search; OCR `content` stripped by default (`include_content=True` to opt in). `notes[].note` and `custom_fields[].value` are always stripped on hits. |
+| `get_document` | Retrieve document metadata by ID; OCR `content` stripped by default (`include_content=True` to opt in) |
 | `get_document_content` | Retrieve the plain-text content of a document |
 | `create_document` | Upload a new document for ingestion |
 | `update_document` | Patch document metadata (title, tags, correspondent, etc.) |
@@ -20,6 +20,10 @@ Paperless MCP exposes the following tools to MCP clients.
 | `create_download_link` | Generate a time-limited download URL |
 
 `get_document`, `list_documents`, `search_documents`, and `update_document` include a `web_url` field pointing to the document in the Paperless UI (e.g. `https://paperless.example.com/documents/42/`). Set `PAPERLESS_MCP_PAPERLESS_PUBLIC_URL` if the public URL differs from the API URL; otherwise the API URL is used.
+
+### Pagination
+
+All paginated tools return `next`/`previous` as bare `page=N` markers (or `None`). Upstream Paperless URLs are normalised away so the internal hostname never leaks into MCP responses; both server-paginated (documents, tags, ...) and client-paginated (tasks) endpoints now share a single shape. Callers pass `page=N` explicitly to fetch subsequent pages.
 
 ## Tag tools
 

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -22,6 +22,22 @@ from paperless_mcp.models.document import (
 )
 
 
+def _strip_listing_heavy_fields(doc: Document, *, include_content: bool) -> None:
+    """Drop per-document heavy fields from list/search responses (see #30).
+
+    Always strips ``notes[].note`` and ``custom_fields[].value`` — metadata refs
+    (ids, timestamps, field refs) stay intact so callers can still detect
+    presence and dereference via single-document endpoints.  OCR ``content``
+    is only stripped when ``include_content`` is ``False``.
+    """
+    if not include_content:
+        doc.content = None
+    for note in doc.notes:
+        note.note = None
+    for cf in doc.custom_fields:
+        cf.value = None
+
+
 class DocumentsClient:
     """Async operations against ``/api/documents/``."""
 
@@ -54,7 +70,10 @@ class DocumentsClient:
             custom_field: Filter by custom field ID.
             include_content: When ``False`` (default), strips the OCR
                 ``content`` field from every result to keep responses small.
-                Set to ``True`` to retain the full text.
+                Set to ``True`` to retain the full text.  ``notes[].note``
+                and ``custom_fields[].value`` are always stripped on list
+                responses regardless of this flag (see #30); use
+                ``get_document_notes`` and ``get_document`` to fetch them.
 
         Returns:
             Paginated list of matching :class:`Document` objects.
@@ -74,9 +93,8 @@ class DocumentsClient:
             params["custom_fields__id"] = custom_field
         body = await self._http.get_json("/api/documents/", params=params)
         result = Paginated[Document].model_validate(body)
-        if not include_content:
-            for doc in result.results:
-                doc.content = None
+        for doc in result.results:
+            _strip_listing_heavy_fields(doc, include_content=include_content)
         return result
 
     async def search(
@@ -97,7 +115,9 @@ class DocumentsClient:
             more_like: Return documents similar to this document ID.
             include_content: When ``False`` (default), strips the OCR
                 ``content`` field from every hit to keep responses small.
-                Set to ``True`` to retain the full text.
+                Set to ``True`` to retain the full text.  ``notes[].note``
+                and ``custom_fields[].value`` are always stripped on search
+                responses regardless of this flag (see #30).
 
         Returns:
             Paginated list of matching :class:`Document` objects.
@@ -109,9 +129,8 @@ class DocumentsClient:
             params["query"] = query
         body = await self._http.get_json("/api/documents/", params=params)
         result = Paginated[Document].model_validate(body)
-        if not include_content:
-            for doc in result.results:
-                doc.content = None
+        for doc in result.results:
+            _strip_listing_heavy_fields(doc, include_content=include_content)
         return result
 
     async def get(self, document_id: int) -> Document:

--- a/src/paperless_mcp/client/documents.py
+++ b/src/paperless_mcp/client/documents.py
@@ -29,6 +29,13 @@ def _strip_listing_heavy_fields(doc: Document, *, include_content: bool) -> None
     (ids, timestamps, field refs) stay intact so callers can still detect
     presence and dereference via single-document endpoints.  OCR ``content``
     is only stripped when ``include_content`` is ``False``.
+
+    Layer note: stripping for **bulk** endpoints (list, search) happens here
+    in the client layer so any direct consumer of :class:`PaperlessClient`
+    gets the same behaviour as an MCP caller.  Stripping for **single-document**
+    endpoints (``get_document``, ``update_document``) happens at the tool
+    layer instead — ``PaperlessClient.get()``/``update()`` always return the
+    full document so server-side logic and resources can use the full model.
     """
     if not include_content:
         doc.content = None

--- a/src/paperless_mcp/models/common.py
+++ b/src/paperless_mcp/models/common.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from enum import StrEnum
 from typing import Generic, Literal, TypeVar
 from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -27,6 +30,10 @@ def _normalise_page_marker(value: str | None) -> str | None:
     pages = parse_qs(query).get("page")
     if pages and pages[0].isdigit():
         return f"page={pages[0]}"
+    # Surface unexpected shapes (cursor/offset pagination, malformed URLs) at
+    # WARNING so the normalised ``None`` — which otherwise silently stops
+    # pagination — is traceable in production.
+    logger.warning("normalise_page_marker unexpected_shape value=%r", value)
     return None
 
 

--- a/src/paperless_mcp/models/common.py
+++ b/src/paperless_mcp/models/common.py
@@ -4,10 +4,30 @@ from __future__ import annotations
 
 from enum import StrEnum
 from typing import Generic, Literal, TypeVar
+from urllib.parse import parse_qs, urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 T = TypeVar("T")
+
+
+def _normalise_page_marker(value: str | None) -> str | None:
+    """Return ``page=N`` for any URL or query fragment, ``None`` otherwise.
+
+    Paperless-paginated endpoints echo back upstream URLs like
+    ``http://paperless-ngx:8000/api/documents/?page=2`` which leak the internal
+    hostname and are inconsistent with client-paginated endpoints (see #32).
+    Normalising here guarantees both shapes collapse to ``page=2``.
+    """
+    if value is None:
+        return None
+    # Accept full URL or bare query fragment. ``urlparse`` only populates
+    # ``.query`` when a scheme/netloc is present, so fall back to the raw value.
+    query = urlparse(value).query or value
+    pages = parse_qs(query).get("page")
+    if pages and pages[0].isdigit():
+        return f"page={pages[0]}"
+    return None
 
 
 class Paginated(BaseModel, Generic[T]):
@@ -17,6 +37,11 @@ class Paginated(BaseModel, Generic[T]):
     next: str | None = None
     previous: str | None = None
     results: list[T] = Field(default_factory=list)
+
+    @field_validator("next", "previous", mode="after")
+    @classmethod
+    def _strip_upstream_url(cls, value: str | None) -> str | None:
+        return _normalise_page_marker(value)
 
 
 class ListParams(BaseModel):

--- a/src/paperless_mcp/models/document.py
+++ b/src/paperless_mcp/models/document.py
@@ -21,7 +21,10 @@ class CustomFieldInstance(BaseModel):
 class DocumentNote(BaseModel):
     model_config = ConfigDict(extra="allow")
     id: int
-    note: str
+    # ``note`` is nullable on list/search responses where it's stripped for
+    # payload size (see #30); single-document note endpoints return the full
+    # text.
+    note: str | None = None
     created: datetime
     user: UserId = None
 

--- a/src/paperless_mcp/tools/documents.py
+++ b/src/paperless_mcp/tools/documents.py
@@ -100,9 +100,19 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         return result
 
     @register_tool(mcp, "get_document", read_only_mode=read_only)
-    async def get_document(document_id: int) -> Document:
-        """Fetch one document by ID."""
+    async def get_document(
+        document_id: int,
+        include_content: bool = False,
+    ) -> Document:
+        """Fetch one document by ID.
+
+        By default, the OCR ``content`` is stripped to keep responses small.
+        Pass ``include_content=True`` for the full text, or call
+        ``get_document_content`` to retrieve just the text.
+        """
         doc = await client.documents.get(document_id)
+        if not include_content:
+            doc.content = None
         _with_web_url(doc)
         return doc
 
@@ -142,9 +152,19 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         return await client.documents.get_suggestions(document_id)
 
     @register_tool(mcp, "update_document", read_only_mode=read_only)
-    async def update_document(document_id: int, patch: DocumentPatch) -> Document:
-        """Patch selected fields on a document."""
+    async def update_document(
+        document_id: int,
+        patch: DocumentPatch,
+        include_content: bool = False,
+    ) -> Document:
+        """Patch selected fields on a document.
+
+        The response strips OCR ``content`` by default; pass
+        ``include_content=True`` to get the full text back.
+        """
         doc = await client.documents.update(document_id, patch)
+        if not include_content:
+            doc.content = None
         _with_web_url(doc)
         return doc
 

--- a/src/paperless_mcp/tools/documents.py
+++ b/src/paperless_mcp/tools/documents.py
@@ -58,6 +58,12 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
 
         By default, per-document OCR ``content`` is stripped to keep results
         small.  Pass ``include_content=True`` for the full text on each hit.
+
+        ``notes[].note`` and ``custom_fields[].value`` are **always** stripped
+        from listings regardless of ``include_content`` — the metadata refs
+        (note ids, timestamps, custom-field ids) are retained so callers can
+        detect presence, but to read the actual text use ``get_document``
+        (with ``include_content=True`` if needed) or ``get_document_notes``.
         """
         result = await client.documents.list(
             page=page,
@@ -87,6 +93,10 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
         By default per-hit OCR ``content`` is stripped; pass
         ``include_content=True`` to get full OCR text per hit.
         Use *more_like* for similarity search.
+
+        ``notes[].note`` and ``custom_fields[].value`` are **always** stripped
+        from search hits regardless of ``include_content`` — fetch them via
+        ``get_document`` or ``get_document_notes`` when needed.
         """
         result = await client.documents.search(
             query,

--- a/tests/unit/client/test_documents_list_search.py
+++ b/tests/unit/client/test_documents_list_search.py
@@ -207,6 +207,29 @@ async def test_search_strips_notes_and_custom_field_values_by_default(
 
 
 @pytest.mark.asyncio
+async def test_search_strips_heavy_fields_even_when_include_content_true(
+    _documents_page_with_heavy_fields: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    # Mirror of the list() test — search() must also keep notes/custom_field
+    # values stripped when the caller opts into full OCR content.
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page_with_heavy_fields)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.search("foo", include_content=True)
+        finally:
+            await c.aclose()
+    doc = result.results[0]
+    assert doc.content == "B" * 10_000
+    assert doc.notes[0].note is None
+    assert doc.custom_fields[0].value is None
+
+
+@pytest.mark.asyncio
 async def test_list_normalises_upstream_next_url(
     paperless_base_url: str,
     paperless_api_token: str,

--- a/tests/unit/client/test_documents_list_search.py
+++ b/tests/unit/client/test_documents_list_search.py
@@ -100,3 +100,138 @@ async def test_search_keeps_content_when_include_content_true(
         finally:
             await c.aclose()
     assert result.results[0].content == "A" * 50_000
+
+
+@pytest.fixture
+def _documents_page_with_heavy_fields() -> dict[str, Any]:
+    return {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "all": [27],
+        "results": [
+            {
+                "id": 27,
+                "title": "SABSA summary doc",
+                "content": "B" * 10_000,
+                "created": "2026-01-01T00:00:00Z",
+                "tags": [],
+                "notes": [
+                    {
+                        "id": 9,
+                        "note": "N" * 2_000,
+                        "created": "2026-02-01T00:00:00Z",
+                        "user": {"id": 3, "username": "alice"},
+                    }
+                ],
+                "custom_fields": [
+                    {"field": 4, "value": "L" * 1_500},
+                    {"field": 5, "value": 42},
+                ],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_strips_notes_and_custom_field_values_by_default(
+    _documents_page_with_heavy_fields: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page_with_heavy_fields)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.list()
+        finally:
+            await c.aclose()
+    doc = result.results[0]
+    # Heavy text dropped.
+    assert doc.notes[0].note is None
+    assert doc.custom_fields[0].value is None
+    assert doc.custom_fields[1].value is None
+    # Metadata refs retained — callers can still detect presence / dereference.
+    assert doc.notes[0].id == 9
+    assert doc.notes[0].user == 3
+    assert doc.custom_fields[0].field == 4
+    assert doc.custom_fields[1].field == 5
+
+
+@pytest.mark.asyncio
+async def test_list_strips_heavy_fields_even_when_include_content_true(
+    _documents_page_with_heavy_fields: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    # include_content=True retains OCR content but notes/custom_field values
+    # are always stripped on list responses — callers must use single-document
+    # endpoints to fetch them.
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page_with_heavy_fields)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.list(include_content=True)
+        finally:
+            await c.aclose()
+    doc = result.results[0]
+    assert doc.content == "B" * 10_000
+    assert doc.notes[0].note is None
+    assert doc.custom_fields[0].value is None
+
+
+@pytest.mark.asyncio
+async def test_search_strips_notes_and_custom_field_values_by_default(
+    _documents_page_with_heavy_fields: dict[str, Any],
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(
+            return_value=httpx.Response(200, json=_documents_page_with_heavy_fields)
+        )
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.search("foo")
+        finally:
+            await c.aclose()
+    doc = result.results[0]
+    assert doc.notes[0].note is None
+    assert doc.custom_fields[0].value is None
+    assert doc.notes[0].id == 9
+    assert doc.custom_fields[0].field == 4
+
+
+@pytest.mark.asyncio
+async def test_list_normalises_upstream_next_url(
+    paperless_base_url: str,
+    paperless_api_token: str,
+) -> None:
+    page = {
+        "count": 2,
+        "next": "http://paperless-ngx:8000/api/documents/?page=2",
+        "previous": None,
+        "results": [
+            {
+                "id": 1,
+                "title": "T",
+                "content": "x",
+                "created": "2026-01-01T00:00:00Z",
+                "tags": [],
+            }
+        ],
+    }
+    async with respx.mock(base_url=paperless_base_url) as mock:
+        mock.get("/api/documents/").mock(return_value=httpx.Response(200, json=page))
+        c = PaperlessClient(base_url=paperless_base_url, api_token=paperless_api_token)
+        try:
+            result = await c.documents.list()
+        finally:
+            await c.aclose()
+    # Upstream hostname must not leak into the MCP response.
+    assert result.next == "page=2"
+    assert result.previous is None

--- a/tests/unit/models/test_common.py
+++ b/tests/unit/models/test_common.py
@@ -38,6 +38,10 @@ def test_paginated_parses_results() -> None:
     )
     assert [r.id for r in page.results] == [1, 2]
     assert page.results[0].extra == "hi"  # type: ignore[attr-defined]
+    # The ``next`` URL is normalised to a bare ``page=N`` marker by the
+    # Paginated validator; assert it here so the fixture shape doesn't
+    # silently drift from the normalised output shape.
+    assert page.next == "page=2"
 
 
 def test_paginated_normalises_full_url_next_to_page_marker() -> None:
@@ -74,16 +78,25 @@ def test_paginated_passthrough_bare_page_marker() -> None:
     assert page.next == "page=2"
 
 
-def test_paginated_next_without_page_param_becomes_none() -> None:
-    page = Paginated[_Item].model_validate(
-        {
-            "count": 1,
-            "next": "http://paperless-ngx:8000/api/documents/",
-            "previous": None,
-            "results": [{"id": 1}],
-        }
-    )
+def test_paginated_next_without_page_param_becomes_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger="paperless_mcp.models.common"):
+        page = Paginated[_Item].model_validate(
+            {
+                "count": 1,
+                "next": "http://paperless-ngx:8000/api/documents/",
+                "previous": None,
+                "results": [{"id": 1}],
+            }
+        )
     assert page.next is None
+    # Surfacing unexpected pagination shapes at WARNING helps operators
+    # diagnose silently-truncated walks in production.
+    assert any(
+        "normalise_page_marker unexpected_shape" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_paginated_next_none_stays_none() -> None:

--- a/tests/unit/models/test_common.py
+++ b/tests/unit/models/test_common.py
@@ -40,6 +40,60 @@ def test_paginated_parses_results() -> None:
     assert page.results[0].extra == "hi"  # type: ignore[attr-defined]
 
 
+def test_paginated_normalises_full_url_next_to_page_marker() -> None:
+    page = Paginated[_Item].model_validate(
+        {
+            "count": 3,
+            "next": "http://paperless-ngx:8000/api/documents/?page=2",
+            "previous": None,
+            "results": [{"id": 1}],
+        }
+    )
+    assert page.next == "page=2"
+    assert page.previous is None
+
+
+def test_paginated_normalises_previous_url() -> None:
+    page = Paginated[_Item].model_validate(
+        {
+            "count": 3,
+            "next": None,
+            "previous": "http://paperless-ngx:8000/api/documents/?page=1&tag=4",
+            "results": [{"id": 3}],
+        }
+    )
+    assert page.previous == "page=1"
+
+
+def test_paginated_passthrough_bare_page_marker() -> None:
+    # Client-paginated endpoints (tasks) already emit "page=N"; the validator
+    # must leave that shape unchanged.
+    page = Paginated[_Item].model_validate(
+        {"count": 1, "next": "page=2", "previous": None, "results": [{"id": 1}]}
+    )
+    assert page.next == "page=2"
+
+
+def test_paginated_next_without_page_param_becomes_none() -> None:
+    page = Paginated[_Item].model_validate(
+        {
+            "count": 1,
+            "next": "http://paperless-ngx:8000/api/documents/",
+            "previous": None,
+            "results": [{"id": 1}],
+        }
+    )
+    assert page.next is None
+
+
+def test_paginated_next_none_stays_none() -> None:
+    page = Paginated[_Item].model_validate(
+        {"count": 1, "next": None, "previous": None, "results": [{"id": 1}]}
+    )
+    assert page.next is None
+    assert page.previous is None
+
+
 def test_paginated_drops_all_ids_from_upstream() -> None:
     page = Paginated[_Item].model_validate(
         {

--- a/tests/unit/tools/test_documents.py
+++ b/tests/unit/tools/test_documents.py
@@ -140,6 +140,120 @@ async def test_get_document_populates_web_url(mock_client: Any) -> None:
     assert data["web_url"] == "https://docs.example.com/documents/42/"
 
 
+def test_get_document_and_update_document_expose_include_content(
+    mock_client: Any,
+) -> None:
+    mcp = FastMCP("test")
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
+    documents_mod.register(mcp, ctx)
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    for name in ("get_document", "update_document"):
+        schema = tools[name].parameters
+        assert "include_content" in schema["properties"], name
+        assert schema["properties"]["include_content"].get("default") is False
+
+
+@pytest.mark.asyncio
+async def test_get_document_strips_content_by_default(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.get.return_value = Document(
+        id=42,
+        title="X",
+        created=datetime(2026, 1, 1, tzinfo=UTC),
+        content="A" * 50_000,
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool("get_document", {"document_id": 42})
+
+    data = result.structured_content
+    assert data is not None
+    assert data["content"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_keeps_content_when_include_content_true(
+    mock_client: Any,
+) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client, read_only=True, default_page_size=25, public_url=""
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.get.return_value = Document(
+        id=42,
+        title="X",
+        created=datetime(2026, 1, 1, tzinfo=UTC),
+        content="OCR text",
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool(
+            "get_document", {"document_id": 42, "include_content": True}
+        )
+
+    data = result.structured_content
+    assert data is not None
+    assert data["content"] == "OCR text"
+
+
+@pytest.mark.asyncio
+async def test_update_document_strips_content_by_default(mock_client: Any) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.update.return_value = Document(
+        id=42,
+        title="X",
+        created=datetime(2026, 1, 1, tzinfo=UTC),
+        content="A" * 50_000,
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool(
+            "update_document", {"document_id": 42, "patch": {"title": "Y"}}
+        )
+
+    data = result.structured_content
+    assert data is not None
+    assert data["content"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_document_keeps_content_when_include_content_true(
+    mock_client: Any,
+) -> None:
+    mcp = FastMCP("t")
+    ctx = ToolContext(
+        client=mock_client, read_only=False, default_page_size=25, public_url=""
+    )
+    documents_mod.register(mcp, ctx)
+    mock_client.documents.update.return_value = Document(
+        id=42,
+        title="X",
+        created=datetime(2026, 1, 1, tzinfo=UTC),
+        content="OCR text",
+    )
+
+    async with Client(mcp) as c:
+        result = await c.call_tool(
+            "update_document",
+            {"document_id": 42, "patch": {"title": "Y"}, "include_content": True},
+        )
+
+    data = result.structured_content
+    assert data is not None
+    assert data["content"] == "OCR text"
+
+
 @pytest.mark.asyncio
 async def test_list_documents_populates_web_url(mock_client: Any) -> None:
     mcp = FastMCP("t")

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.0rc2"
+version = "1.0.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

This PR optimizes API response payloads by stripping heavy fields from list and search responses, and adds explicit `include_content` parameter control to single-document endpoints. It also normalizes pagination URLs to prevent internal hostname leakage.

## Key Changes

- **Strip heavy fields from list/search responses**: `notes[].note` and `custom_fields[].value` are now always stripped from `list()` and `search()` responses to reduce payload size. Metadata references (IDs, field refs) are retained so callers can still detect presence and dereference via single-document endpoints. OCR `content` is stripped by default but can be retained with `include_content=True`.

- **Add `include_content` parameter to single-document endpoints**: `get_document()` and `update_document()` tools now accept an `include_content` parameter (default `False`) to control whether OCR content is included in responses, matching the behavior of list/search endpoints.

- **Normalize pagination URLs**: The `Paginated` model now normalizes upstream pagination URLs (e.g., `http://paperless-ngx:8000/api/documents/?page=2`) to bare page markers (e.g., `page=2`), preventing internal hostname leakage and ensuring consistency with client-paginated endpoints.

- **Update DocumentNote model**: Made `note` field nullable (`str | None = None`) to reflect that it's stripped on list/search responses.

- **Comprehensive test coverage**: Added tests for content stripping behavior, pagination URL normalization, and the new `include_content` parameter on both client and tool layers.

## Implementation Details

- New helper function `_strip_listing_heavy_fields()` centralizes the logic for stripping heavy fields from documents in list/search responses
- New helper function `_normalise_page_marker()` handles URL parsing and normalization for pagination links
- Pydantic field validator on `Paginated` model automatically normalizes `next` and `previous` URLs during deserialization
- Documentation updated to clarify stripping behavior and guide users to single-document endpoints for full data

https://claude.ai/code/session_01GqTktH7FSuLj1Ar667Yee4