### PR TITLE
fix(v1.0.1): error wrapping + remove broken bulk_edit_custom_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Paperless-NGX document management over MCP: search, tag, upload, and read docume
 - **Tag, correspondent, document-type, custom-field management** — full CRUD and bulk-edit for every classification dimension Paperless exposes.
 - **Document lifecycle** — upload new documents, update fields, attach notes, and inspect audit history and AI-suggested tags/correspondents/types.
 - **Operational introspection** — saved views, storage paths, share links, background tasks (with `wait_for_task`), statistics, and remote Paperless-NGX version.
-- **MCP tools** — 52 LLM-visible tools with Lucide icons and read-only gating; see `src/paperless_mcp/tools/`.
+- **MCP tools** — 50 LLM-visible tools with Lucide icons and read-only gating; see `src/paperless_mcp/tools/`.
 - **MCP resources** — 20 URIs exposing documents and domain collections; see `src/paperless_mcp/resources/`.
 - **Read-only mode** — flip `PAPERLESS_MCP_READ_ONLY=true` to disable every mutating tool at startup.
 <!-- DOMAIN-END -->
@@ -194,7 +194,6 @@ Paginated tools return `next`/`previous` as bare `page=N` markers (never full UR
 | `create_custom_field` | Create a new custom field |
 | `update_custom_field` | Update a custom field |
 | `delete_custom_field` | Delete a custom field |
-| `bulk_edit_custom_fields` | Bulk edit custom fields |
 
 ### Observability
 

--- a/docs/superpowers/specs/2026-04-23-paperless-mcp-design.md
+++ b/docs/superpowers/specs/2026-04-23-paperless-mcp-design.md
@@ -182,7 +182,9 @@ Each gets the standard quintet:
 - `bulk_edit_tags(operation, ids, **params) -> BulkEditResult`
 - `bulk_edit_correspondents(operation, ids, **params) -> BulkEditResult`
 - `bulk_edit_document_types(operation, ids, **params) -> BulkEditResult`
-- `bulk_edit_custom_fields(operation, ids, **params) -> BulkEditResult`
+
+Custom fields are intentionally excluded: Paperless-NGX's `bulk_edit_objects`
+endpoint does not accept `object_type=custom_fields` (see issue #38).
 
 ### Read-only observability
 - `list_storage_paths(...)`, `get_storage_path(id)`

--- a/src/paperless_mcp/client/custom_fields.py
+++ b/src/paperless_mcp/client/custom_fields.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-
 from paperless_mcp.client._http import PaperlessHTTP
-from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.custom_field import (
     CustomField,
     CustomFieldCreate,
@@ -14,9 +12,13 @@ from paperless_mcp.models.custom_field import (
 
 
 class CustomFieldsClient:
-    """Async operations against ``/api/custom_fields/``."""
+    """Async operations against ``/api/custom_fields/``.
 
-    _OBJECT_TYPE = "custom_fields"
+    No ``bulk_edit`` method: Paperless-NGX's ``/api/bulk_edit_objects/``
+    endpoint does not accept ``object_type=custom_fields`` (see
+    ``BulkEditObjectsSerializer`` in paperless-ngx upstream — the choices are
+    ``tags``, ``correspondents``, ``document_types``, ``storage_paths``).
+    """
 
     def __init__(self, http: PaperlessHTTP) -> None:
         self._http = http
@@ -92,29 +94,3 @@ class CustomFieldsClient:
             field_id: ID of the custom field to delete.
         """
         await self._http.delete(f"/api/custom_fields/{field_id}/")
-
-    async def bulk_edit(
-        self,
-        *,
-        operation: str,
-        ids: Sequence[int],
-        parameters: dict[str, object] | None = None,
-    ) -> BulkEditResult:
-        """Perform a bulk edit operation on multiple custom fields.
-
-        Args:
-            operation: The operation to perform (e.g. ``"set_permissions"``).
-            ids: List of custom field IDs to act on.
-            parameters: Optional extra parameters for the operation.
-
-        Returns:
-            A :class:`BulkEditResult` with the operation result.
-        """
-        payload: dict[str, object] = {
-            "object_type": self._OBJECT_TYPE,
-            "objects": ids,
-            "operation": operation,
-            "parameters": parameters or {},
-        }
-        body = await self._http.post_json("/api/bulk_edit_objects/", json=payload)
-        return BulkEditResult.model_validate(body)

--- a/src/paperless_mcp/tools/_annotations.py
+++ b/src/paperless_mcp/tools/_annotations.py
@@ -86,7 +86,6 @@ ANNOTATION_REGISTRY: dict[str, dict[str, bool]] = {
     "create_custom_field": _CREATE,
     "update_custom_field": _UPDATE,
     "delete_custom_field": _DELETE,
-    "bulk_edit_custom_fields": _BULK_EDIT,
     # Observability
     "list_storage_paths": _READ,
     "get_storage_path": _READ,

--- a/src/paperless_mcp/tools/_icons.py
+++ b/src/paperless_mcp/tools/_icons.py
@@ -64,7 +64,6 @@ ICON_REGISTRY: dict[str, list[Icon]] = {
     "create_custom_field": [_icon("form-input")],
     "update_custom_field": [_icon("pencil")],
     "delete_custom_field": [_icon("trash-2")],
-    "bulk_edit_custom_fields": [_icon("list-checks")],
     # Observability
     "list_storage_paths": [_icon("hard-drive")],
     "get_storage_path": [_icon("hard-drive")],

--- a/src/paperless_mcp/tools/_registry.py
+++ b/src/paperless_mcp/tools/_registry.py
@@ -18,6 +18,7 @@ from typing import TypeVar
 
 import httpx
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from mcp.types import Icon
 from pydantic import ValidationError as PydanticValidationError
 
@@ -34,6 +35,13 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
     # ``PaperlessAPIError`` before they reach us, so the two ``httpx.*``
     # branches below are defensive safety nets for any call path that
     # bypasses ``PaperlessHTTP._request`` (e.g. future one-off httpx calls).
+    #
+    # We raise ``ToolError`` rather than returning an error string: returning a
+    # string conflicts with tools whose declared output schema is a typed model
+    # (``Tag``, ``Paginated[Tag]``, ...). FastMCP would refuse to coerce the
+    # string into ``structured_content``. Raising ``ToolError`` lets the MCP
+    # layer emit a proper ``CallToolResult(isError=True)`` regardless of the
+    # tool's output schema.
     @functools.wraps(func)
     async def wrapper(*args: object, **kwargs: object) -> object:
         try:
@@ -42,7 +50,9 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
             logger.warning(
                 "tool_api_error tool=%s status=%s msg=%s", name, exc.status_code, exc
             )
-            return f"Paperless API error {exc.status_code}: {exc.detail}"
+            raise ToolError(
+                f"Paperless API error {exc.status_code}: {exc.detail}"
+            ) from exc
         except httpx.HTTPStatusError as exc:
             api_exc = error_from_response(exc.response)
             logger.warning(
@@ -51,10 +61,12 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
                 api_exc.status_code,
                 exc.request.url,
             )
-            return f"Paperless API error {api_exc.status_code}: {api_exc.detail}"
+            raise ToolError(
+                f"Paperless API error {api_exc.status_code}: {api_exc.detail}"
+            ) from exc
         except httpx.RequestError as exc:
             logger.warning("tool_network_error tool=%s error=%s", name, exc)
-            return f"Network error connecting to Paperless: {exc}"
+            raise ToolError(f"Network error connecting to Paperless: {exc}") from exc
         except PydanticValidationError as exc:
             errors = exc.errors()
             detail = (
@@ -65,9 +77,9 @@ def _wrap_with_error_handling(name: str, func: F) -> F:
             logger.warning(
                 "tool_validation_error tool=%s errors=%d", name, exc.error_count()
             )
-            return (
+            raise ToolError(
                 f"Response validation failed ({exc.error_count()} error(s)): {detail}"
-            )
+            ) from exc
 
     return wrapper  # type: ignore[return-value]
 

--- a/src/paperless_mcp/tools/custom_fields.py
+++ b/src/paperless_mcp/tools/custom_fields.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from fastmcp import FastMCP
 from pydantic import Field
 
-from paperless_mcp.models.common import BulkEditResult, Paginated
+from paperless_mcp.models.common import Paginated
 from paperless_mcp.models.custom_field import (
     CustomField,
     CustomFieldCreate,
@@ -84,14 +84,3 @@ def register(mcp: FastMCP, ctx: ToolContext) -> None:
     async def delete_custom_field(field_id: int) -> None:
         """Delete a custom field."""
         await client.custom_fields.delete(field_id)
-
-    @register_tool(mcp, "bulk_edit_custom_fields", read_only_mode=read_only)
-    async def bulk_edit_custom_fields(
-        operation: str,
-        ids: list[int],
-        parameters: dict[str, object] | None = None,
-    ) -> BulkEditResult:
-        """Apply a bulk operation to a set of custom fields."""
-        return await client.custom_fields.bulk_edit(
-            operation=operation, ids=ids, parameters=parameters
-        )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -26,6 +26,6 @@ async def test_all_tools_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     async with Client(server) as client:
         tools = await client.list_tools()
     names = {t.name for t in tools}
-    assert len(tools) >= 50
+    assert len(tools) >= 49
     for expected in ("list_documents", "create_tag", "wait_for_task", "get_statistics"):
         assert expected in names, f"missing tool: {expected}"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -26,6 +26,9 @@ async def test_all_tools_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     async with Client(server) as client:
         tools = await client.list_tools()
     names = {t.name for t in tools}
+    # 50 tools are registered with an artifact store; the stdio path used here
+    # has no store, so ``create_download_link`` is not registered — hence 49.
     assert len(tools) >= 49
+    assert "create_download_link" not in names
     for expected in ("list_documents", "create_tag", "wait_for_task", "get_statistics"):
         assert expected in names, f"missing tool: {expected}"

--- a/tests/unit/client/test_custom_fields_write.py
+++ b/tests/unit/client/test_custom_fields_write.py
@@ -62,14 +62,10 @@ async def test_delete(custom_fields) -> None:
     assert route.called
 
 
-@pytest.mark.asyncio
-async def test_bulk_edit(custom_fields) -> None:
-    async with respx.mock(base_url="http://paperless.test") as mock:
-        route = mock.post("/api/bulk_edit_objects/").mock(
-            return_value=httpx.Response(200, json={"result": "OK"})
-        )
-        result = await custom_fields.bulk_edit(operation="set_permissions", ids=[2])
-    assert result.result == "OK"
-    assert (
-        json.loads(route.calls.last.request.content)["object_type"] == "custom_fields"
-    )
+def test_bulk_edit_method_does_not_exist(
+    custom_fields: CustomFieldsClient,
+) -> None:
+    """Paperless rejects ``object_type=custom_fields`` on
+    ``/api/bulk_edit_objects/``, so no ``bulk_edit`` method is exposed.
+    """
+    assert not hasattr(custom_fields, "bulk_edit")

--- a/tests/unit/tools/test_crud_resources.py
+++ b/tests/unit/tools/test_crud_resources.py
@@ -38,16 +38,20 @@ def _names(mcp: FastMCP) -> set[str]:
     return {t.name for t in tools}
 
 
-@pytest.mark.parametrize(
-    ("module", "prefix"),
-    [
-        (tags_mod, "tag"),
-        (correspondents_mod, "correspondent"),
-        (document_types_mod, "document_type"),
-        (custom_fields_mod, "custom_field"),
-    ],
-)
-def test_read_only_registers_read_tools_only(module: Any, prefix: str) -> None:
+# (module, prefix, has_bulk_edit). custom_fields has no bulk_edit because
+# Paperless's bulk_edit_objects endpoint does not accept object_type=custom_fields.
+_CRUD_MODULES: list[tuple[Any, str, bool]] = [
+    (tags_mod, "tag", True),
+    (correspondents_mod, "correspondent", True),
+    (document_types_mod, "document_type", True),
+    (custom_fields_mod, "custom_field", False),
+]
+
+
+@pytest.mark.parametrize(("module", "prefix", "has_bulk_edit"), _CRUD_MODULES)
+def test_read_only_registers_read_tools_only(
+    module: Any, prefix: str, has_bulk_edit: bool
+) -> None:
     mcp = FastMCP("test")
     ctx = ToolContext(
         client=_mock_client(), read_only=True, default_page_size=25, public_url=""
@@ -62,16 +66,8 @@ def test_read_only_registers_read_tools_only(module: Any, prefix: str) -> None:
     assert f"bulk_edit_{prefix}s" not in names
 
 
-@pytest.mark.parametrize(
-    ("module", "prefix"),
-    [
-        (tags_mod, "tag"),
-        (correspondents_mod, "correspondent"),
-        (document_types_mod, "document_type"),
-        (custom_fields_mod, "custom_field"),
-    ],
-)
-def test_all_tools_have_icons(module: Any, prefix: str) -> None:
+@pytest.mark.parametrize(("module", "prefix", "has_bulk_edit"), _CRUD_MODULES)
+def test_all_tools_have_icons(module: Any, prefix: str, has_bulk_edit: bool) -> None:
     from paperless_mcp.tools._icons import ICON_REGISTRY
 
     mcp = FastMCP("test")
@@ -84,16 +80,10 @@ def test_all_tools_have_icons(module: Any, prefix: str) -> None:
         assert name in ICON_REGISTRY, f"tool {name!r} missing from ICON_REGISTRY"
 
 
-@pytest.mark.parametrize(
-    ("module", "prefix"),
-    [
-        (tags_mod, "tag"),
-        (correspondents_mod, "correspondent"),
-        (document_types_mod, "document_type"),
-        (custom_fields_mod, "custom_field"),
-    ],
-)
-def test_read_write_registers_all(module: Any, prefix: str) -> None:
+@pytest.mark.parametrize(("module", "prefix", "has_bulk_edit"), _CRUD_MODULES)
+def test_read_write_registers_all(
+    module: Any, prefix: str, has_bulk_edit: bool
+) -> None:
     mcp = FastMCP("test")
     ctx = ToolContext(
         client=_mock_client(), read_only=False, default_page_size=25, public_url=""
@@ -106,9 +96,12 @@ def test_read_write_registers_all(module: Any, prefix: str) -> None:
         f"create_{prefix}",
         f"update_{prefix}",
         f"delete_{prefix}",
-        f"bulk_edit_{prefix}s",
     }
+    if has_bulk_edit:
+        expected.add(f"bulk_edit_{prefix}s")
     assert expected.issubset(names)
+    if not has_bulk_edit:
+        assert f"bulk_edit_{prefix}s" not in names
 
 
 def test_custom_field_tool_descriptions_mention_select_options() -> None:

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -39,6 +39,9 @@ async def test_wrap_raises_tool_error_on_paperless_api_error() -> None:
         await wrapped()
     assert str(excinfo.value).startswith("Paperless API error 404:")
     assert "No Tag matches" in str(excinfo.value)
+    # ``raise ... from exc`` must preserve the cause so the original Paperless
+    # error remains visible in tracebacks and ``__cause__`` walks.
+    assert isinstance(excinfo.value.__cause__, NotFoundError)
 
 
 @pytest.mark.asyncio
@@ -58,6 +61,7 @@ async def test_wrap_raises_tool_error_on_httpx_status_error() -> None:
         await wrapped()
     assert str(excinfo.value).startswith("Paperless API error 404:")
     assert "Not found" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, httpx.HTTPStatusError)
 
 
 @pytest.mark.asyncio
@@ -74,12 +78,14 @@ async def test_wrap_raises_tool_error_on_request_error() -> None:
     with pytest.raises(ToolError) as excinfo:
         await wrapped()
     assert "Network error connecting to Paperless" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, httpx.ConnectError)
 
 
 @pytest.mark.asyncio
 async def test_wrap_raises_tool_error_on_pydantic_validation_error() -> None:
     from fastmcp.exceptions import ToolError
     from pydantic import BaseModel
+    from pydantic import ValidationError as PydanticValidationError
 
     from paperless_mcp.tools._registry import _wrap_with_error_handling
 
@@ -94,3 +100,4 @@ async def test_wrap_raises_tool_error_on_pydantic_validation_error() -> None:
     with pytest.raises(ToolError) as excinfo:
         await wrapped()
     assert str(excinfo.value).startswith("Response validation failed (1 error(s)):")
+    assert isinstance(excinfo.value.__cause__, PydanticValidationError)

--- a/tests/unit/tools/test_registry.py
+++ b/tests/unit/tools/test_registry.py
@@ -25,8 +25,26 @@ def test_load_svg_missing(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_wrap_catches_httpx_status_error() -> None:
+async def test_wrap_raises_tool_error_on_paperless_api_error() -> None:
+    from fastmcp.exceptions import ToolError
+
+    from paperless_mcp.client._errors import NotFoundError
+    from paperless_mcp.tools._registry import _wrap_with_error_handling
+
+    async def boom() -> object:
+        raise NotFoundError(404, "No Tag matches the given query.")
+
+    wrapped = _wrap_with_error_handling("get_tag", boom)
+    with pytest.raises(ToolError) as excinfo:
+        await wrapped()
+    assert str(excinfo.value).startswith("Paperless API error 404:")
+    assert "No Tag matches" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_wrap_raises_tool_error_on_httpx_status_error() -> None:
     import httpx
+    from fastmcp.exceptions import ToolError
 
     from paperless_mcp.tools._registry import _wrap_with_error_handling
 
@@ -36,14 +54,31 @@ async def test_wrap_catches_httpx_status_error() -> None:
         raise httpx.HTTPStatusError("404", request=request, response=response)
 
     wrapped = _wrap_with_error_handling("delete_document_note", boom)
-    result = await wrapped()
-    assert isinstance(result, str)
-    assert result.startswith("Paperless API error 404:")
-    assert "Not found" in result
+    with pytest.raises(ToolError) as excinfo:
+        await wrapped()
+    assert str(excinfo.value).startswith("Paperless API error 404:")
+    assert "Not found" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
-async def test_wrap_catches_pydantic_validation_error() -> None:
+async def test_wrap_raises_tool_error_on_request_error() -> None:
+    import httpx
+    from fastmcp.exceptions import ToolError
+
+    from paperless_mcp.tools._registry import _wrap_with_error_handling
+
+    async def boom() -> object:
+        raise httpx.ConnectError("name resolution failed")
+
+    wrapped = _wrap_with_error_handling("get_tag", boom)
+    with pytest.raises(ToolError) as excinfo:
+        await wrapped()
+    assert "Network error connecting to Paperless" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_wrap_raises_tool_error_on_pydantic_validation_error() -> None:
+    from fastmcp.exceptions import ToolError
     from pydantic import BaseModel
 
     from paperless_mcp.tools._registry import _wrap_with_error_handling
@@ -56,6 +91,6 @@ async def test_wrap_catches_pydantic_validation_error() -> None:
         return None
 
     wrapped = _wrap_with_error_handling("delete_document_note", boom)
-    result = await wrapped()
-    assert isinstance(result, str)
-    assert result.startswith("Response validation failed (1 error(s)):")
+    with pytest.raises(ToolError) as excinfo:
+        await wrapped()
+    assert str(excinfo.value).startswith("Response validation failed (1 error(s)):")

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.0rc3"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
## Summary

Two narrow bug fixes surfaced by the v1.0.0 release validation report (round 4). Both are isolated, low-risk, and target the v1.0.1 patch.

- **`fix(tools)`** — Tool wrapper now raises `ToolError` instead of returning an error string when a Paperless API call fails. Returning a string conflicted with FastMCP's structured-output validation, causing a framework-level wrapping error (`structured_content must be a dict or None. Got str: ...`) that masked the original Paperless error from the LLM. Affects every `get_*`-by-id and `bulk_*` tool. Single-source-of-truth fix in `src/paperless_mcp/tools/_registry.py::_wrap_with_error_handling`.
- **`fix(custom-fields)`** — `bulk_edit_custom_fields` always returns a 400 from Paperless-NGX because the upstream `bulk_edit_objects` serializer does not accept `object_type=custom_fields` (verified against `BulkEditObjectsSerializer` upstream — choices are `tags`, `correspondents`, `document_types`, `storage_paths`). Tool, underlying client method, and registry entries removed. Design spec updated to record the exclusion.

## Test plan

- [x] `uv run pytest -x -q` — 193 passed, 1 skipped
- [x] `uv run ruff check --fix .` then `uv run ruff format .` then `uv run ruff format --check .` — all clean
- [x] `uv run mypy src/ tests/` — no issues
- [x] Patch coverage: `src/paperless_mcp/tools/_registry.py` at 100%, all four error branches exercised
- [x] `git grep bulk_edit_custom_fields` outside `docs/superpowers/plans/` — empty
- [ ] Manual smoke test against a live instance once deployed: `get_tag(<missing-id>)` should produce a clean MCP error result with the Paperless message, not a wrapping error

## Out of scope (left for future work)

The validation report also raised a quality-of-life request for a `get_mcp_version`-style tool. Filed upstream as **pvliesdonk/fastmcp-pvl-core#17** so all template-derived servers can pick it up at once; not implemented here.

Closes #37, closes #38
Refs pvliesdonk/fastmcp-pvl-core#17

🤖 Generated with [Claude Code](https://claude.com/claude-code)