### PR TITLE
chore: gitignore local Claude/tooling directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,22 @@ site/
 # --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-.claude/worktrees/
-.claude/settings.local.json
 docs/superpowers/
+# Everything under .claude/ is local EXCEPT skills/ — that subtree ships the
+# contributor-facing authoring skill(s), template-owned and re-rendered on
+# copier update (project additions live inside its DOMAIN-AUTHORING sentinel).
+.claude/*
+!.claude/skills/
+# No trailing slash: `.mcp.json/` would match a *directory* of that name and
+# leave the actual file tracked.
+.mcp.json
+.repowise/
+
+# Editor-local config. Deliberately just this one — a contributor's choice of
+# editor is theirs, and this list is not meant to grow into a catalogue of
+# every IDE. `.vscode/` earns its place because it is the common case and
+# because several tools (repowise among them) write into it unprompted, so it
+# reappears in `git status` for contributors who never opted in. A team that
+# does want to share workspace settings can track a specific file with
+# `git add -f .vscode/settings.json`.
+.vscode/


### PR DESCRIPTION
## Summary
- First prep step in the fastmcp-server-template v1.2.0 → v5.6.3 upgrade.
- `.claude/`, `.mcp.json`, `.repowise/`, `.vscode/` were untracked; adopts the template's end-state gitignore rules for them so the first `copier update` diff is readable.

Closes #72

## Test plan
- [x] `.gitignore` change only, no code affected
- [x] `pre-commit run --all-files` (via commit hooks) passed