### PR TITLE
chore(copier): update to v4.1.0

### DIFF
--- a/.claude/skills/authoring-issues-prs/SKILL.md
+++ b/.claude/skills/authoring-issues-prs/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: authoring-issues-prs
+description: >-
+  Use when filing a bug, opening or creating a GitHub issue, drafting an
+  epic or ticket, writing up a finding or review observation worth
+  tracking, or opening a pull request for this repository. Routes the
+  change to the right repo first (library / template / domain), picks the
+  right issue form, links epic children as native sub-issues, and applies
+  CONTRIBUTING.md before anything is posted.
+---
+
+<!-- ===== TEMPLATE-OWNED — re-rendered on copier update. Project-specific
+     additions go inside the DOMAIN-AUTHORING sentinel at the end. ===== -->
+
+# Authoring issues and pull requests
+
+`CONTRIBUTING.md` at the repository root is the single source for the rules:
+issue voice, uncertainty markers, one-issue-one-problem, PR discipline, and
+the three-tier routing. This skill adds only what a document cannot — the
+trigger, the order of operations, and the API mechanics for the steps issue
+forms cannot perform. It deliberately does not restate the rules; a second
+copy would drift from the file silently.
+
+## Procedure
+
+### 1. Read CONTRIBUTING.md — now, not from memory
+
+Read `CONTRIBUTING.md` (repository root) before drafting a single sentence,
+even if you believe you remember it. You are about to apply these sections,
+and their exact wording matters:
+
+- "Observation, not work order" and "The uncertainty rule" — issue voice
+  and the `[verified: how]` / `[unverified]` markers.
+- "One issue, one observed problem" and the "Remove before posting" table —
+  run your draft through the table before submitting.
+- "Pull requests" — no orphan PRs, the deliberately-does-not section.
+- "Where to send fixes" — the routing walked in step 2.
+
+If anything in this skill appears to conflict with `CONTRIBUTING.md`, the
+file wins.
+
+### 2. Route before writing
+
+Decide the repo first, then write for that repo. The test: **which file
+would a fix change?**
+
+1. Anything you'd change in `fastmcp_pvl_core` → **library**: file on
+   `pvliesdonk/fastmcp-pvl-core`.
+2. A template-owned file — workflows, `Dockerfile`, the `server.py`
+   skeleton, anything `copier update` re-renders — → **template**: file on
+   `pvliesdonk/fastmcp-server-template`.
+3. Anything inside a `DOMAIN-*` / `CONFIG-*` / `PROJECT-*` sentinel block,
+   or `tools.py` / `resources.py` / `prompts.py` / `domain.py` / `tests/`
+   → **domain**: file on this repository.
+
+`CONTRIBUTING.md`'s "Where to send fixes" defines these tiers with the
+post-merge propagation for each. When the tier is genuinely unclear, say so
+in the issue with an `[unverified]` marker instead of guessing silently.
+
+### 3. Search for duplicates
+
+Search the target repo's issues — open **and** closed — before filing:
+
+```bash
+gh issue list --repo OWNER/REPO --state all --search "<key terms>"
+```
+
+Match on the observation, not the wording. If the problem is already on
+file, comment on the existing issue rather than opening a twin; if a closed
+issue shows it regressed, say that in the new issue and link it.
+
+### 4. Pick the form
+
+Forms live in `.github/ISSUE_TEMPLATE/` of the target repo:
+
+| You have | Form |
+|----------|------|
+| Something not working as expected | `bug-report.yml` |
+| A capability that's missing | `feature-request.yml` |
+| A multi-feature effort telling one user-facing story | `epic.yml` |
+| Structural decay worth refactoring later | `decay.yml` |
+| A question or support request | `question.yml` |
+
+When filing via API/CLI rather than the web form, mirror the chosen form's
+section headings and apply its labels (`bug`, `feature`, `epic`, `decay`,
+`question`) so the issue is indistinguishable from a form-filed one.
+
+### 5. For epics: finish what the form cannot do
+
+Issue forms cannot create sub-issue links or assign milestones. After the
+epic is filed, perform these steps — this is the mechanical half of the
+epic form's "After filing" checklist:
+
+```bash
+repo=OWNER/REPO        # the repo decided in step 2
+epic=EPIC_NUMBER
+
+# 1. Link each child as a NATIVE sub-issue (the endpoint takes the child's
+#    database id, not its issue number):
+child_id=$(gh api "repos/$repo/issues/CHILD_NUMBER" --jq '.id')
+gh api -X POST "repos/$repo/issues/$epic/sub_issues" -F "sub_issue_id=$child_id"
+
+# 2a. Ships atomically — milestone (preferred): assign the epic AND its
+#     children to the target release's milestone, creating it if needed.
+#     Milestones are per-repo and one-per-issue; for a cross-repo epic the
+#     milestone lives in the repo where the release is cut.
+gh api "repos/$repo/milestones" -F "title=X.Y"     # once, if it doesn't exist
+gh issue edit "$epic" --repo "$repo" --milestone "X.Y"
+
+# 2b. Ships atomically — label (fallback): when no target release is named
+#     yet, or in the repos of a cross-repo epic that do not cut the release.
+gh issue edit "$epic" --repo "$repo" --add-label ships-atomically
+```
+
+Working through the GitHub MCP server instead: `sub_issue_write` (method
+`add`) performs the same link, and `issue_read` returns `has_parent` /
+`has_children` / `sub_issues_summary` to verify it took.
+
+Never track children as a markdown task list in the epic body — the native
+link is what release tooling queries.
+
+### 6. Pull requests
+
+Route first (step 2): the issue and the PR that closes it belong in the
+same repo. Then follow `CONTRIBUTING.md`'s "Pull requests" section and the
+repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) — every section,
+including "What this PR deliberately does NOT do" and the docs-impact
+checklist.
+
+### 7. Attribution footer
+
+When you (an agent) author an issue or PR body, end it with exactly:
+
+```markdown
+---
+_Generated by [Claude Code](https://claude.ai/code)_
+```
+
+<!-- DOMAIN-AUTHORING-START -->
+<!-- Project-specific authoring conventions (extra labels, forms, routing
+     notes) go here. This block survives copier update. -->
+<!-- DOMAIN-AUTHORING-END -->

--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: writing-release-notes
+description: >-
+  Use when drafting or revising a release-notes page under docs/releases/ —
+  the Release Notes workflow invokes it after every stable release, and a
+  human may invoke it for a re-draft or backfill. Walks the API-driven
+  research fan-out (commits to PRs to linked issues, never commit subjects),
+  the evidence contract, the per-minor page format, and the Vale loop, and
+  ends with pages written for a pull request — never a direct push.
+---
+
+<!-- ===== TEMPLATE-OWNED — re-rendered on template updates. ===== -->
+
+# Writing release notes
+
+The pages under `docs/releases/` are the canonical human-facing narrative of
+each release; the GitHub release body is a summary plus a link to them, and
+`CHANGELOG.md` is the machine-written commit-level audit trail. This skill is
+the contract for producing a page: what to research, what counts as evidence,
+what the page looks like, and which gates it must pass. Every requirement
+below was established empirically by trial runs recorded on
+pvliesdonk/fastmcp-server-template#347; where this skill says "must", a trial
+produced the failure the rule prevents.
+
+## Inputs
+
+You are given, or must derive first:
+
+- `TAG` / `VERSION` — the stable release (e.g. `v3.2.0` / `3.2.0`).
+- `MINOR` — the series (e.g. `3.2`); the page is `docs/releases/MINOR.md`.
+- `PREV` — the highest stable tag strictly below `TAG` (series-aware,
+  `sort -V`); empty on a first release.
+- Mode — **new page** (first stable of the minor: write the whole page) or
+  **patch append** (the page exists: add one dated section for this patch,
+  inside the patch sentinels; leave the rest of the page alone unless it is
+  factually wrong).
+
+## Non-negotiables
+
+1. **No evidence, no narrative.** Every causal claim ("X was slow because
+   Y", "this was driven by user demand") must trace to a linked issue or PR
+   you actually read, and the page links it. A claim you cannot source gets
+   dropped, not hedged. Concrete numbers appear only verbatim from a source.
+   Attribute quoted judgements (for example "[per the maintainer]" with the
+   link) rather than presenting them as your own analysis.
+2. **Output is a pull request, never a push.** The dominant failure mode is
+   plausible-but-wrong rationale, and a confabulated "why" on a published
+   docs site is worse than no narrative. A human merges the page; write the
+   PR body to make that evidence check easy.
+3. **Never touch `CHANGELOG.md`.** It is machine-generated and stays that
+   way. The two artifacts answer different questions: "what landed" versus
+   "should I upgrade".
+4. **Never write from `git log`.** Commit subjects are the input ceiling this
+   whole pipeline exists to break. A draft whose sections mirror the commit
+   list is the recognised failure ("a haiku summary of the git log") — if you
+   notice the page reading like grouped commit subjects, the research phase
+   was skipped; go back.
+
+## Research procedure
+
+### 1. Enumerate the range through the API, not local git
+
+- Commit list: `gh api "repos/OWNER/REPO/compare/PREV...TAG"` (paginate past
+  250 commits; if PREV is empty this is the whole history — fall back to the
+  release's own compare link or the full commit list). The compare API is
+  authoritative; a shallow local clone silently truncates ranges.
+- Commit to PR: `gh api "repos/OWNER/REPO/commits/SHA/pulls"` — never regex
+  `(#N)` out of subjects (breaks on squash subjects without the suffix and
+  on passing mentions).
+- PR to issues: the PR's closing-issues references (GraphQL
+  `closingIssuesReferences` on the PR object) — never grep `Closes #N` from
+  bodies; UI-made links have no text form.
+
+### 2. Group before you read deeply
+
+Build the theme map from structure first:
+
+- **Epics are the primary grouping input.** For each linked issue, check for
+  a parent (native sub-issues; epics carry the `epic` label). An epic whose
+  children closed in this range is one theme, and its issue form's "What
+  changes for the user" paragraph — written at epic creation — is the seed
+  for both that theme's section and the release summary. Verify that
+  paragraph against what actually landed; edit it, do not just copy it.
+- The release **milestone** (or the `ships-atomically` label) marks work
+  that was planned to ship together — treat it as one story.
+- Everything else falls into themes by subject (each significant feature,
+  contributor-driven changes, platform/infrastructure work, fixes). Where a
+  repository has no epics or milestones, this thematic grouping is the whole
+  map — degrade gracefully; do not invent structure.
+
+### 3. Fan out — one research pass per theme
+
+A single agent holding the whole range regresses to commit subjects, because
+reading the linked issues does not fit alongside drafting. Dispatch **parallel
+research subagents, one per theme**. Each walks its theme's commits → PRs →
+issue bodies **and comments**, and returns a compact structured brief:
+
+- what shipped, in user terms, with the PR/issue links;
+- the motivating problem, quoted from the issue body where possible;
+- who reported or drove it: the issue's `user.login` and
+  `author_association`, not just commit authors;
+- exact enablement: env vars, defaults, config keys, tool names;
+- any concrete numbers (timings, sizes, counts) with their source;
+- the feature's docs page(s), and whether they changed in this range.
+
+The synthesiser writes **from the briefs only**.
+
+### 4. Attribution comes from issue authorship
+
+Commit authors miss most outside contributors: people who file the issue that
+the maintainer then implements are invisible in `git log`. Report reporters.
+Corollary: do not infer outside demand from an issue the maintainer filed —
+if an outside PR preceded the maintainer's tracking issue, the honest
+attribution is the PR.
+
+### 5. Synthesis pass, with licence to regroup
+
+After the briefs return, look across them before writing: separate
+deliverables may be one recipe with several delivery channels (write the
+"which do I want" paragraph, not three bullets), and a fix filed under one
+scope may really belong to another theme's story. Conventional-commit scopes
+are not the outline; the reader's questions are.
+
+## Writing the page
+
+Each significant feature answers, in this order:
+
+1. **What is it** — for someone who has never heard of it.
+2. **Why does it fit this server** — almost always a verbatim quote from the
+   motivating issue; it is never in a commit.
+3. **How do I enable it** — exact env vars, defaults, config; a reader should
+   be able to act without opening another page (but link the guide too).
+4. Then, and only then, the tool/API surface it added.
+
+A list of tools shipped is the failure mode, not the deliverable.
+
+### Upgrade / breaking-changes section
+
+Do **not** trust `!` markers or `BREAKING CHANGE:` footers — trials found
+them wrong in both directions. Derive the section from the actual surfaces
+between `PREV` and `TAG`, classified against the breaking-change policy in
+`CLAUDE.md` (operator surface and public library interface, assessed against
+the last stable):
+
+- import surface: diff `tests/public_import_surface.txt` at the two tags
+  (`git show PREV:tests/public_import_surface.txt`);
+- operator surface: diff `.env.example` / the config surface at the two tags;
+- tool surface: compare the registered-tools docs at the two tags (not
+  breaking on its own, but worth a migration note when behaviour moved).
+
+Where your classification disagrees with a commit's marker, follow the
+classification and say so in the PR body.
+
+### Docs links — verify before linking
+
+Every feature with a docs page links it, not only the flagship. Locate pages
+rather than assuming them, and **check each linked page is current**: a
+feature whose code changed in the range while its guide did not is a
+candidate staleness bug. Do not link a page you found stale as if it were
+authoritative; list every staleness candidate in the PR body (observation
+voice, `[unverified]` where you did not confirm) so the maintainer can file
+or fix — do not file issues yourself from an automated run.
+
+## Page format
+
+One page per minor: `docs/releases/MINOR.md`. Patch releases append a dated
+section to the same page, so a minor's story stays in one linkable document.
+Skeleton for a new page (the comment markers are load-bearing — the publish
+workflow extracts summary blocks by tag, and later patch drafts insert only
+inside the patch sentinels):
+
+    # 3.2
+
+    <!-- RELEASE-SUMMARY v3.2.0 START -->
+    One short paragraph, user-facing: what this minor means for someone
+    deciding whether to upgrade. Seeded from the epic form's summary where
+    one exists. This block becomes the GitHub release body.
+    <!-- RELEASE-SUMMARY v3.2.0 END -->
+
+    ## <theme sections, per the writing rules above>
+
+    ## Upgrading
+
+    <the derived upgrade section; omit heading if truly nothing>
+
+    <!-- PATCH-RELEASES-START -->
+    <!-- PATCH-RELEASES-END -->
+
+A patch section goes inside the patch sentinels, oldest first, as:
+
+    ## v3.2.1 — 2026-08-20
+
+    <!-- RELEASE-SUMMARY v3.2.1 START -->
+    One paragraph: what this patch fixes and who should care.
+    <!-- RELEASE-SUMMARY v3.2.1 END -->
+
+    <evidence-linked detail, same rules as above>
+
+For a **new** page, also add the minor to the list in
+`docs/releases/index.md` (newest first, between its markers; the first real
+entry replaces the seeded placeholder line). Do not edit
+`mkdocs.yml`: the navigation is project-owned. If the nav has no
+Release Notes entry yet, note that in the PR body instead of adding one.
+
+## Quality gates — run them, do not assume them
+
+- **Vale** is the prose gate, including the `ai-tells` LLM-prose detector:
+  run `vale docs/releases/` (the binary and synced style packs are provided
+  by the workflow; locally, `vale sync` first) and iterate until clean.
+  Distinguish the two hit classes: real prose findings get rewritten;
+  domain vocabulary the spell-checker does not know goes into
+  `.vale/styles/config/vocabularies/Base/accept.txt` (add it in the same
+  change) — never contort prose around a vocabulary hit.
+- **Strict docs build**: `uv run mkdocs build --strict` must pass.
+
+## Output
+
+Leave the working tree holding only: the release page, `docs/releases/index.md`
+(new-page mode), any `accept.txt` additions, and your proposed PR body in
+`.release-notes-pr-body.md` at the repository root (the workflow's mechanical
+step commits the docs paths, opens the PR from the body file, and discards
+the body file). The PR body must carry:
+
+- the release tag and compare link;
+- a claim-by-claim evidence summary (or a statement that every inline link
+  is the evidence), so the human review is a link check, not archaeology;
+- your breaking-change classification and any disagreement with `!` markers;
+- docs-staleness candidates found in the research;
+- anything you could not source and therefore left out.
+
+**Honest failure beats confident junk.** If the range has too few linked
+issues to support a narrative, write the modest factual page the evidence
+supports. If you cannot produce even that, change nothing and say why in
+your final report — the release stands with its interim body, and nothing
+downstream breaks.

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by `copier update`.
-_commit: v3.6.0
+_commit: v4.1.0
 _src_path: gh:pvliesdonk/fastmcp-server-template
 docker_registry: ghcr.io/pvliesdonk
 domain_description: 'Paperless-NGX document management over MCP: search, tag, upload,

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,92 @@
+name: Epic
+description: >
+  A multi-feature effort that ships as one user-facing story. Children are
+  linked as native GitHub sub-issues, not markdown checklists. See
+  CONTRIBUTING.md for how epics are structured.
+title: "[Epic]: "
+labels: ["epic"]
+body:
+  - type: textarea
+    id: user-facing-summary
+    attributes:
+      label: What changes for the user
+      description: >
+        One paragraph, written now, before any code exists. This is the
+        highest-value field: it becomes the release-notes highlight for the
+        whole epic, so write it for the user reading the notes, not for the
+        implementer. Release tooling edits and verifies this text against
+        what actually landed rather than reconstructing intent afterwards.
+      placeholder: "After this epic, you can ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: surface-impact
+    attributes:
+      label: Surface impact
+      description: >
+        Which compatibility surfaces this epic touches. Decided once at epic
+        creation and inherited by the children, rather than argued per
+        commit; feeds the breaking-change policy.
+      multiple: true
+      options:
+        - Operator surface (config, env vars, CLI, deployment)
+        - Public library API
+        - MCP tool surface (tools, resources, prompts)
+        - None (internal only)
+    validations:
+      required: true
+  - type: dropdown
+    id: ships-atomically
+    attributes:
+      label: Ships atomically
+      description: >
+        If yes, no release may be cut while this epic is mid-flight. This
+        answer records the intent; the machine-readable signal release
+        tooling queries is a milestone or label set after filing (see the
+        checklist below) — forms cannot assign either.
+      options:
+        - "Yes — no release may be cut mid-epic"
+        - "No — children can ship independently"
+    validations:
+      required: true
+  - type: textarea
+    id: children
+    attributes:
+      label: Planned children
+      description: >
+        The planned child issues, one per line ("#N" for issues that already
+        exist, a one-line description for those that don't yet). This list
+        is planning prose only — the queryable relationship is the native
+        sub-issue link, created after filing (see the checklist below). Do
+        not maintain a markdown task list as the source of truth.
+    validations:
+      required: false
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What this epic deliberately does not cover.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### After filing (issue forms cannot do these)
+
+        Forms cannot create sub-issue links or assign milestones, so finish
+        the epic setup after submitting. The `authoring-issues-prs` skill
+        (`.claude/skills/authoring-issues-prs/SKILL.md`) performs these
+        steps mechanically.
+
+        1. **Link the children as native sub-issues** — issue sidebar
+           ("Create sub-issue" / "Add existing issue") or the sub-issues
+           API. This makes the grouping queryable (`has_parent`,
+           `sub_issues_summary`) instead of prose to pattern-match.
+        2. **If the epic ships atomically, make that queryable:**
+           - **Milestone (preferred):** assign the epic and its children to
+             the milestone of the target release, creating it if needed.
+             Milestones are per-repo and one-per-issue; for a cross-repo
+             epic the milestone lives in the repo where the release is cut.
+           - **Label (fallback):** apply `ships-atomically` when no target
+             release is named yet, or in the repos of a cross-repo epic
+             that do not cut the release.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,9 @@ found nothing.
 ## Local review
 
 - [ ] Ran a local code-review pass on the cumulative diff before `gh pr create`.
+- [ ] Any commit carrying `!` breaks an operator or library surface that
+      existed at the **last stable release** (see the breaking-change policy
+      in `CLAUDE.md`) — MCP tool-surface changes alone do not earn a `!`.
 
 ## Docs impact
 

--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -1,0 +1,43 @@
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI Success" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/protect-release-branches.json
+++ b/.github/rulesets/protect-release-branches.json
@@ -1,0 +1,43 @@
+{
+  "name": "protect-release-branches",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/release/**"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "CI Success" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/protect-release-tags.json
+++ b/.github/rulesets/protect-release-tags.json
@@ -1,0 +1,22 @@
+{
+  "name": "protect-release-tags",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -3,30 +3,39 @@ name: Bootstrap repo
 # Seeds repository state that checked-in config references but GitHub does not
 # create on its own:
 #   1. The `dependencies` label Renovate applies to its PRs, plus the
-#      `bug`/`feature`/`decay`/`question` labels the issue forms reference
-#      (GitHub silently drops labels that don't exist).
+#      `bug`/`feature`/`decay`/`question`/`epic` labels the issue forms
+#      reference (GitHub silently drops labels that don't exist) and the
+#      `ships-atomically` label the epic workflow uses as the fallback
+#      release-cut signal when no milestone names the target release.
 #   2. Repository settings that make Renovate auto-merge SAFE — "Allow
-#      auto-merge" plus branch protection requiring the `CI Success` check.
+#      auto-merge" plus the checked-in rulesets (`.github/rulesets/*.json`)
+#      requiring PRs and the `CI Success` check on `main` and `release/*`.
 #      Without a required check, enabling auto-merge on a PR merges it
 #      immediately; the gate is what holds the merge until CI is green.
+#      Posture, bypass model, and per-branch rules are documented in
+#      docs/deployment/repository-protection.md.
 #
-# Idempotent: label create is `--force`; the settings/branch-protection calls
-# are PATCH/PUT that converge to the same state on every run. The first push to
-# the default branch applies everything; `workflow_dispatch` re-applies on demand.
+# Idempotent: label create is `--force`; the settings call is a PATCH and the
+# ruleset apply upserts by name (PUT onto the existing id, POST otherwise), so
+# every run converges to the checked-in state. The first push to the default
+# branch applies everything; a push touching this workflow or a ruleset file
+# re-applies; `workflow_dispatch` re-applies on demand.
 #
-# Auth: the settings + branch-protection calls need `administration:write`,
-# which the default GITHUB_TOKEN lacks — they use RELEASE_TOKEN.
+# Auth: the settings + ruleset calls need `administration:write`, which the
+# default GITHUB_TOKEN lacks — they use RELEASE_TOKEN.
 
 on:
   push:
     branches: [main]
     paths:
       - .github/workflows/bootstrap.yml
+      - .github/rulesets/**
       - renovate.json
   workflow_dispatch:
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   labels:
@@ -58,12 +67,22 @@ jobs:
             --color d876e3 \
             --description "Further information is requested" \
             --force
+          gh label create epic \
+            --color 3e4b9e \
+            --description "Multi-feature effort that ships as one user-facing story" \
+            --force
+          gh label create ships-atomically \
+            --color b60205 \
+            --description "No release may be cut while this epic is mid-flight (fallback for a release milestone)" \
+            --force
 
   settings:
-    name: Enable auto-merge + branch protection
+    name: Enable auto-merge + repository rulesets
     runs-on: ubuntu-latest
     steps:
-      - name: Allow auto-merge and require CI Success on main
+      - uses: actions/checkout@v7
+
+      - name: Allow auto-merge
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
@@ -71,26 +90,59 @@ jobs:
           # Enable repository-level auto-merge.
           gh api -X PATCH "repos/${REPO}" -F allow_auto_merge=true
 
-          # Require the single drift-proof CI Success context. No required
-          # reviews (a solo account has no second reviewer — requiring one would
-          # deadlock patch/minor auto-merge). enforce_admins=false keeps a
-          # direct-push hotfix path for the owner.
+      - name: Apply repository rulesets
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Upsert every checked-in ruleset by name: PUT onto the existing
+          # ruleset id when one matches, POST otherwise. The rules require PRs
+          # with ZERO approvals (a solo account has no second reviewer —
+          # requiring one would deadlock patch/minor auto-merge) plus the
+          # single drift-proof CI Success context; the repository-admin bypass
+          # entry keeps the release workflow's RELEASE_TOKEN pushes (PSR's
+          # release commit + tag, the merge-back to main) and the owner's
+          # direct-push hotfix path working — the ruleset equivalent of the
+          # old classic protection's enforce_admins=false.
           #
-          # DESTRUCTIVE-IDEMPOTENT: this is a full PUT of the desired protection
-          # state, not a read-merge-write. Bootstrap declaratively OWNS main's
-          # branch protection — any protections added by hand via the GitHub UI
-          # (extra required checks, required reviewers, push restrictions) are
-          # reset to exactly the state below on the next run. Add such settings
-          # here, not in the UI, or they will not stick.
-          gh api -X PUT "repos/${REPO}/branches/main/protection" \
-            --input - <<'JSON'
-          {
-            "required_status_checks": {
-              "strict": true,
-              "contexts": ["CI Success"]
-            },
-            "enforce_admins": false,
-            "required_pull_request_reviews": null,
-            "restrictions": null
-          }
-          JSON
+          # DESTRUCTIVE-IDEMPOTENT: each PUT replaces the whole ruleset with
+          # the checked-in state, not a read-merge-write. Bootstrap
+          # declaratively OWNS these rulesets — edits made by hand in the
+          # GitHub UI are reset on the next run. Change the JSON files
+          # instead, or the edits will not stick. Rulesets with other names
+          # are left alone.
+          #
+          # includes_parents=false keeps org-level rulesets out of the name
+          # match — an org ruleset that happens to share a name must not
+          # receive a repo-level PUT (wrong id, wrong scope).
+          existing=$(gh api \
+            "repos/${REPO}/rulesets?per_page=100&includes_parents=false")
+          for file in .github/rulesets/*.json; do
+            name=$(jq -r '.name' "$file")
+            id=$(jq -r --arg name "$name" \
+              'map(select(.name == $name)) | first | .id // empty' \
+              <<<"$existing")
+            if [ -n "$id" ]; then
+              echo "Updating ruleset '${name}' (id ${id}) from ${file}"
+              gh api -X PUT "repos/${REPO}/rulesets/${id}" \
+                --input "$file" >/dev/null
+            else
+              echo "Creating ruleset '${name}' from ${file}"
+              gh api -X POST "repos/${REPO}/rulesets" \
+                --input "$file" >/dev/null
+            fi
+          done
+
+      - name: Retire classic branch protection on main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Earlier template versions protected main via the classic
+          # branch-protection API. The rulesets above supersede it, and the
+          # two systems LAYER (most restrictive wins), so a lingering classic
+          # rule would keep enforcing a stale posture no checked-in file
+          # describes. Delete it; the API's 404 ("Branch not protected") is
+          # the steady state on repos bootstrapped after this migration.
+          gh api -X DELETE "repos/${REPO}/branches/main/protection" \
+            || echo "No classic branch protection to remove — already migrated."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
-    branches: [main]
+    # release/** keeps backport PRs CI-gated: the shipped rulesets
+    # (.github/rulesets/) require the CI Success check on release/* exactly
+    # as on main, which deadlocks unless CI actually runs there.
+    branches: [main, "release/**"]
   workflow_dispatch:
 
 jobs:
@@ -415,19 +418,48 @@ jobs:
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Structural quality (changed lines only)
+        # One implementation, shared with the pre-push hook. The explicit
+        # STRUCTURAL_GATE_BASE pins the PR's actual base branch (main or a
+        # release/X.Y for backport PRs); the script's no-Python skip and the
+        # diff-quality invocation live in the script.
         env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Skip when the diff touches no Python — mirrors the diff-cover guard.
-          HAS_PY=$(git diff --name-only "origin/${BASE_REF}...HEAD" | grep -c '\.py$' || true)
-          if [ "$HAS_PY" -eq 0 ]; then
-            echo "No Python source changes — skipping structural diff gate"
-            exit 0
-          fi
-          uv run diff-quality --violations=ruff.check \
-            --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
-            --compare-branch="origin/${BASE_REF}" --fail-under=100
+          STRUCTURAL_GATE_BASE: origin/${{ github.base_ref }}
+        run: bash scripts/structural_gate.sh
 
+
+  pr-title:
+    name: PR Title
+    # A squash merge takes the pull-request title as the commit subject, and
+    # python-semantic-release drops a subject it cannot parse from
+    # CHANGELOG.md silently — not under a fallback heading, absent. This is
+    # the last point at which that subject can still be corrected.
+    #
+    # PR-only by design: the writers to `main` outside a merge are PSR's own
+    # release commit and the automated merge-back, both machine-generated and
+    # already conformant. On push/dispatch the job is skipped, which the
+    # `ci-success` aggregate below treats as a pass.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check pull-request title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # Read the CURRENT title from the API rather than from
+        # `github.event.pull_request.title`. A re-run replays the original
+        # event payload, so an author who fixes the title would otherwise have
+        # to push a commit to clear a red check that a retitle already fixed.
+        run: |
+          set -euo pipefail
+          TITLE="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .title)"
+          python3 scripts/check_pr_title.py "$TITLE"
 
   ci-success:
     name: CI Success
@@ -442,6 +474,7 @@ jobs:
       - audit
       - secrets
       - vale
+      - pr-title
 
       - structure
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,10 +3,11 @@ name: Claude Code Review
 on:
   pull_request:
     # Match ci.yml's trigger. The review is gated on CI (wait-for-ci job), and
-    # the generated ci.yml only runs on PRs targeting main — firing the reviewer
-    # on other-target PRs would just idle the poll to its timeout, then skip.
-    # Broaden both together if a downstream gates CI on more branches.
-    branches: [main]
+    # the generated ci.yml only runs on PRs targeting main or release/* —
+    # firing the reviewer on other-target PRs would just idle the poll to its
+    # timeout, then skip. Broaden both together if a downstream gates CI on
+    # more branches.
+    branches: [main, "release/**"]
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # On release events the triggering tag may move after the workflow is
-          # queued (semantic-release pushes a version-bump commit); build main.
-          ref: ${{ github.event_name == 'release' && 'main' || github.ref }}
+          # On release events, build the released tag: the release may have
+          # been cut from a release/X.Y branch, where `main` describes code
+          # that is not in the release.  The tag is safe to build since the
+          # version-bump commit lands inside the release commit the tag points
+          # at (see scripts/bump_manifests.py) — tags no longer move.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -59,21 +62,31 @@ jobs:
 
   deploy:
     # Publish versioned docs with mike, serving from the gh-pages branch:
-    #   stable release (prerelease=false) -> version <major.minor> + `latest` alias (default)
-    #   rc prerelease  (prerelease=true)  -> single rolling `unstable` version
+    #   stable release -> version <major.minor>; the `latest` alias (and
+    #                     set-default) move ONLY when the release is at least
+    #                     the current `latest` — a backport patch cut from an
+    #                     old release/X.Y updates its own minor's page and
+    #                     never repoints `latest` at the older series
+    #   push to main   -> single rolling `unstable` version: the docs face of
+    #                     the edge channel, following merged code continuously
+    #   rc prerelease  -> no deploy; rcs are rare branch-scoped stabilisation
+    #                     builds whose docs ship when the stable ships
     #
     # One-time setup before the first deploy (per-project, cannot be templated):
     #   1. Seed gh-pages:
     #        uv run mike deploy --push --update-aliases unstable --title "unstable (<ver>)"
     #   2. Repo Settings -> Pages -> Deploy from a branch -> gh-pages / (root).
     #   Order matters: seed (1) before switching source (2) so the site is never empty.
-    if: github.event_name == 'release'
+    if: github.event_name == 'push' || (github.event_name == 'release' && !github.event.release.prerelease)
     needs: build
-    # Serialize all release deploys (no cancellation) so two releases close
-    # together never push to gh-pages concurrently.
+    # Separate buckets per trigger: rolling-unstable deploys may cancel each
+    # other (only the newest merge matters) but must never cancel a pending
+    # release deploy, which GitHub's one-pending-per-group rule would allow in
+    # a shared bucket.  Cross-bucket gh-pages pushes are reconciled by the
+    # fetch-reset-retry loop in the publish step.
     concurrency:
-      group: ${{ github.workflow }}-deploy
-      cancel-in-progress: false
+      group: ${{ github.workflow }}-deploy-${{ github.event_name }}
+      cancel-in-progress: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -84,7 +97,9 @@ jobs:
         with:
           # Full history required: mike reads and pushes the gh-pages branch.
           fetch-depth: 0
-          ref: main
+          # Release deploys build the released tag (see the build job's ref
+          # comment); push deploys build the pushed main commit.
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -105,14 +120,43 @@ jobs:
       - name: Publish versioned docs
         env:
           TAG: ${{ github.event.release.tag_name }}
-          # GitHub renders the JSON boolean as the string "true"/"false".
-          PRERELEASE: ${{ github.event.release.prerelease }}
+          EVENT: ${{ github.event_name }}
         run: |
-          version="${TAG#v}"
-          if [ "$PRERELEASE" = "true" ]; then
-            uv run mike deploy --push unstable --title "unstable (${version})"
-          else
+          # NOTE: deploy_docs is called from an `if` condition, where bash
+          # suppresses errexit — every failure path must propagate explicitly
+          # (bare `return` and the `&&` chain below), or a failed deploy would
+          # read as success.
+          deploy_docs() {
+            if [ "$EVENT" = "push" ]; then
+              uv run mike deploy --push unstable --title "unstable (${GITHUB_SHA:0:7})"
+              return
+            fi
+            version="${TAG#v}"
             minor="$(echo "$version" | cut -d. -f1-2)"
-            uv run mike deploy --push --update-aliases --title "$version" "$minor" latest
-            uv run mike set-default --push latest
-          fi
+            # Order-aware `latest`: read which minor currently holds the alias
+            # from mike's manifest on gh-pages. Empty (no gh-pages yet, or no
+            # alias) means first release — claim it.
+            current="$(git cat-file -p origin/gh-pages:versions.json 2>/dev/null \
+              | python3 -c 'import json,sys; vs=json.load(sys.stdin); print(next((v["version"] for v in vs if "latest" in (v.get("aliases") or [])), ""))' \
+              || true)"
+            if [ -z "$current" ] || [ "$(printf '%s\n%s\n' "$current" "$minor" | sort -V | tail -1)" = "$minor" ]; then
+              uv run mike deploy --push --update-aliases --title "$version" "$minor" latest \
+                && uv run mike set-default --push latest
+            else
+              uv run mike deploy --push --title "$version" "$minor"
+            fi
+          }
+          # Deploys from the push and release buckets can race on gh-pages;
+          # on a rejected push, re-sync the local gh-pages ref to the remote
+          # and redo the deploy on the fresh tip.
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages || true
+            if git rev-parse -q --verify refs/remotes/origin/gh-pages > /dev/null; then
+              git update-ref refs/heads/gh-pages refs/remotes/origin/gh-pages
+            fi
+            if deploy_docs; then
+              exit 0
+            fi
+          done
+          echo "::error::docs deploy failed after 3 attempts"
+          exit 1

--- a/.github/workflows/release-notes-publish.yml
+++ b/.github/workflows/release-notes-publish.yml
@@ -1,0 +1,175 @@
+# Agent-written release notes, half two of two (template#347).  When a
+# release-notes page lands on the default branch (normally by merging the PR
+# the Release Notes workflow opened), two deterministic follow-ups make the
+# merged page the release's front door:
+#
+#   1. Release-body upgrade — the NOTES-GENERATOR SEAM in release.yml wrote
+#      an interim summary+pointers body at release time (template#350's
+#      contract); this workflow replaces that summary with the page's marked
+#      summary block and deep-links the page, keeping the compare and
+#      CHANGELOG pointers.  Only bodies still carrying the interim marker
+#      line are touched, so a hand-tuned body is never clobbered.
+#   2. Versioned-docs redeploy — mike deployed /X.Y/ at release time, before
+#      the page existed, so the deep link would 404 without a redeploy.  The
+#      minor is redeployed from its newest tag with the default branch's
+#      docs/releases/ overlaid.  Pages live only on the default branch
+#      (release branches never carry them), so the overlay is the single
+#      source and a backport patch's section reaches its series' docs no
+#      matter which branch the patch was cut from.
+#
+# Deterministic by design: the agent's output was reviewed and merged in the
+# PR; nothing here generates content.  Human edits to a page republish the
+# same way — the docs redeploy re-runs; the body upgrade does not (see the
+# interim-marker rule above; use `gh release edit` for a body fix).
+name: Release Notes Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/releases/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Serialise with ourselves only; gh-pages races with docs.yml deploys are
+    # reconciled by the fetch-reset-retry loop below, same as docs.yml.
+    concurrency:
+      group: release-notes-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write   # gh release edit + gh-pages push
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history: tags (locate each minor's releases) and the
+          # gh-pages branch (mike) both live outside the pushed commit.
+          fetch-depth: 0
+
+      - name: Find changed release pages
+        id: pages
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          # Cover multi-commit pushes; on a forced push or missing before-SHA
+          # fall back to the head commit alone.
+          if git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            range="${BEFORE}..HEAD"
+          else
+            range="HEAD^..HEAD"
+          fi
+          git diff --name-only --diff-filter=AM "$range" -- 'docs/releases/*.md' \
+            | grep -vE '/index\.md$' > changed-pages.txt || true
+          if [ -s changed-pages.txt ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            cat changed-pages.txt
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "only the index changed — nothing to publish"
+          fi
+
+      - name: Upgrade release bodies from merged pages
+        if: steps.pages.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r page; do
+            minor=$(basename "$page" .md)
+            echo "$minor" | grep -qE '^[0-9]+\.[0-9]+$' \
+              || { echo "::warning::${page} does not follow docs/releases/X.Y.md — skipping"; continue; }
+            tags=$(git tag --list | grep -E "^v${minor//./\\.}\.[0-9]+$" | sort -V || true)
+            [ -n "$tags" ] \
+              || { echo "::warning::no stable tag in the ${minor} series yet — the body upgrade runs once the release exists"; continue; }
+            for TAG in $tags; do
+              # The page carries one marked summary block per release; a tag
+              # without a block (e.g. an old patch nobody wrote up) is left
+              # alone.
+              summary=$(awk -v tag="$TAG" '
+                index($0, "RELEASE-SUMMARY " tag " START") { f=1; next }
+                index($0, "RELEASE-SUMMARY " tag " END")   { f=0 }
+                f' "$page" | awk 'NF {p=1} p' | tac | awk 'NF {p=1} p' | tac)
+              [ -n "$summary" ] || continue
+              body=$(gh release view "$TAG" --json body --jq .body 2>/dev/null || true)
+              [ -n "$body" ] || { echo "no GitHub release for ${TAG} — skipping"; continue; }
+              # Upgrade once: only bodies still carrying release.yml's interim
+              # closing line. Anything else is either already upgraded or
+              # hand-written — leave it alone.
+              printf '%s' "$body" | grep -qF 'Release notes will move to a versioned notes page' \
+                || { echo "${TAG} body already upgraded or hand-edited — leaving it alone"; continue; }
+              ver="${TAG#v}"
+              prev=$(
+                { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | grep -Fvx "$TAG"; echo "$TAG"; } \
+                  | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+              )
+              {
+                printf '%s\n' "$summary"
+                echo
+                echo "- Release notes: https://pvliesdonk.github.io/paperless-mcp/${minor}/releases/${minor}/"
+                if [ -n "$prev" ]; then
+                  echo "- All changes since ${prev}: https://github.com/${REPO}/compare/${prev}...${TAG}"
+                fi
+                echo "- Commit-level detail: [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)"
+              } > release-body.md
+              gh release edit "$TAG" --notes-file release-body.md
+              echo "upgraded ${TAG} from ${page}"
+            done
+          done < changed-pages.txt
+
+      - name: Install uv
+        if: steps.pages.outputs.found == 'true'
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        if: steps.pages.outputs.found == 'true'
+        run: uv python install 3.12
+
+      - name: Install docs dependencies
+        if: steps.pages.outputs.found == 'true'
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Redeploy versioned docs with the merged pages
+        if: steps.pages.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          MAIN_REF=$(git rev-parse HEAD)
+          while IFS= read -r page; do
+            minor=$(basename "$page" .md)
+            echo "$minor" | grep -qE '^[0-9]+\.[0-9]+$' || continue
+            TAG=$(git tag --list | grep -E "^v${minor//./\\.}\.[0-9]+$" | sort -V | tail -1 || true)
+            [ -n "$TAG" ] || continue
+            ver="${TAG#v}"
+            # Build the minor's docs from its newest tag — the content that
+            # release actually shipped — with the default branch's notes
+            # pages overlaid on top.  `--no-sync` reuses the docs venv
+            # installed above instead of re-locking against the tag.
+            git checkout --force "$TAG"
+            git checkout "$MAIN_REF" -- docs/releases
+            deployed=""
+            # Deploys race with docs.yml's push/release buckets on gh-pages;
+            # on a rejected push, re-sync the local gh-pages ref and redo the
+            # deploy on the fresh tip (same loop as docs.yml).
+            for attempt in 1 2 3; do
+              git fetch origin gh-pages || true
+              if git rev-parse -q --verify refs/remotes/origin/gh-pages > /dev/null; then
+                git update-ref refs/heads/gh-pages refs/remotes/origin/gh-pages
+              fi
+              if uv run --no-sync mike deploy --push --title "$ver" "$minor"; then
+                deployed=1
+                break
+              fi
+            done
+            [ "$deployed" = "1" ] \
+              || { echo "::error::docs redeploy for ${minor} failed after 3 attempts"; exit 1; }
+            git checkout --force "$MAIN_REF"
+          done < changed-pages.txt

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,214 @@
+# Agent-written release notes, half one of two (template#347).  After every
+# stable release an agent researches the release range through the GitHub
+# API — commits, their PRs, the PRs' linked issues; never commit subjects —
+# and opens a PR that adds or extends the release's per-minor page under
+# docs/releases/.  The research contract (theme fan-out, evidence rules,
+# page format, Vale loop) lives in .claude/skills/writing-release-notes/;
+# this workflow only supplies context, tools, and the mechanical PR.
+#
+# INVARIANT: nothing here gates or blocks the release path.  By the time
+# this runs, the release has shipped with the interim summary+pointers body
+# release.yml wrote (its NOTES-GENERATOR SEAM step).  A failed or junk run
+# leaves that body standing; re-run via workflow_dispatch when wanted.  The
+# body upgrade and the versioned-docs redeploy happen only after a human
+# merges the notes PR — see release-notes-publish.yml.
+name: Release Notes
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Stable tag to draft notes for (e.g. v1.2.0). Empty = newest stable tag.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    # Stables only: rcs are branch-scoped stabilisation builds that deploy no
+    # versioned docs, and the notes page is per minor (template#350) — the rc
+    # cycle's content lands in the minor's page when the stable finalises,
+    # via the since-previous-stable range below.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    # Serialise drafts: two quick successive releases would race on the same
+    # index page and branch namespace.
+    concurrency:
+      group: release-notes-draft
+      cancel-in-progress: false
+    timeout-minutes: 60
+    permissions:
+      contents: read       # the agent only reads; the PR push uses RELEASE_TOKEN
+      issues: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          # Always the default branch, whatever branch the release was cut
+          # from: notes pages live only there (a backport patch appends to
+          # the page on the default branch; release-notes-publish.yml
+          # overlays these pages onto the tag when redeploying docs, which
+          # is what resolves template#347's patch-page ordering problem).
+          # Research is API-driven, but full depth supplies the tags for the
+          # previous-stable computation and the tag-to-tag surface diffs
+          # (import surface, env examples) the upgrade section derives from.
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          # PAT, so the branch push and PR below trigger CI/review on the
+          # notes PR (GITHUB_TOKEN-created PRs run no workflows).
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Resolve release context
+        id: ctx
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          fi
+          echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "::error::'${TAG}' is not a stable vX.Y.Z tag — notes pages are per stable minor; rcs have no page"; exit 1; }
+          git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null \
+            || { echo "::error::tag ${TAG} not found"; exit 1; }
+          ver="${TAG#v}"
+          minor="${ver%.*}"
+          # Highest stable tag strictly below this release (same series-aware
+          # idiom as release.yml's body step); empty on a first release.
+          prev=$(
+            { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -Fvx "$TAG"; echo "$TAG"; } \
+              | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+          )
+          page="docs/releases/${minor}.md"
+          mode=new
+          [ -f "$page" ] && mode=patch
+          {
+            echo "tag=$TAG"
+            echo "version=$ver"
+            echo "minor=$minor"
+            echo "prev=$prev"
+            echo "page=$page"
+            echo "mode=$mode"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install docs dependencies
+        # Gives the agent a working `uv run mkdocs build --strict` check.
+        run: uv sync --no-default-groups --group docs --frozen
+
+      - name: Install Vale and sync style packs
+        # The Vale CLI pin lives in ci.yml's vale job (kept in lockstep with
+        # pre-commit by the template CI); extract it rather than adding a
+        # third pin surface here.  The synced packs include ai-tells, the
+        # LLM-prose detector that is this pipeline's prose gate.
+        run: |
+          set -euo pipefail
+          VER=$(awk '/^  vale:/{f=1} f && /^[[:space:]]+version:/{print; exit}' \
+              .github/workflows/ci.yml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          [ -n "$VER" ] || { echo "::error::vale version pin not found in ci.yml"; exit 1; }
+          mkdir -p "$RUNNER_TEMP/valebin"
+          TARBALL="vale_${VER}_Linux_64-bit.tar.gz"
+          BASE="https://github.com/vale-cli/vale/releases/download/v${VER}"
+          curl -sSfL -o "$RUNNER_TEMP/$TARBALL" "$BASE/$TARBALL" \
+            || { echo "::error::could not download $BASE/$TARBALL"; exit 1; }
+          curl -sSfL -o "$RUNNER_TEMP/checksums.txt" "$BASE/vale_${VER}_checksums.txt" \
+            || { echo "::error::could not download the vale $VER checksums file"; exit 1; }
+          ( cd "$RUNNER_TEMP" && grep " $TARBALL\$" checksums.txt | sha256sum -c - ) \
+            || { echo "::error::vale $VER tarball failed checksum verification"; exit 1; }
+          tar -xzf "$RUNNER_TEMP/$TARBALL" -C "$RUNNER_TEMP/valebin" vale
+          echo "$RUNNER_TEMP/valebin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/valebin/vale" sync
+
+      # The research contract requires parallel per-theme subagents (Task).
+      # Same pin + rationale as claude-code-review.yml: on Claude Code
+      # >= 2.1.198 claude-code-action drops background subagents before they
+      # finish (claude-code-action#1499), so the fan-out would silently lose
+      # its research. Remove once #1499 is fixed upstream.
+      - name: Install pinned Claude Code (2.1.197, pre-background-subagents)
+        run: |
+          set -euo pipefail
+          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.197
+          BIN="$HOME/.local/bin/claude"
+          test -x "$BIN"
+          "$BIN" --version
+          echo "CLAUDE_BIN=$BIN" >> "$GITHUB_ENV"
+
+      - name: Draft the notes page
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ${{ env.CLAUDE_BIN }}
+          prompt: |
+            Load the writing-release-notes skill (.claude/skills/writing-release-notes/SKILL.md) and follow it end to end for this stable release:
+
+            - repository: ${{ github.repository }}
+            - tag: ${{ steps.ctx.outputs.tag }} (version ${{ steps.ctx.outputs.version }}, minor series ${{ steps.ctx.outputs.minor }})
+            - previous stable: ${{ steps.ctx.outputs.prev }} (empty means first release)
+            - page: ${{ steps.ctx.outputs.page }}
+            - mode: ${{ steps.ctx.outputs.mode }} (new = write the whole page and add it to docs/releases/index.md; patch = append one dated section inside the patch sentinels)
+
+            The vale binary (packs synced) and `uv run mkdocs build --strict` are available for the skill's quality gates. Write your proposed pull-request body to .release-notes-pr-body.md at the repository root. Do not commit, push, or open a PR yourself — the workflow's next step does that mechanically from your working tree.
+          track_progress: true
+          display_report: true
+          include_fix_links: false
+          # Read-only GitHub research (MCP read tools + gh api), Task for the
+          # per-theme fan-out, Skill to load the contract, vale + mkdocs for
+          # the quality loop, and read-only git for tag-to-tag surface diffs.
+          # Edit/Write stay available from the action's defaults; the job's
+          # `contents: read` keeps the agent from pushing anything.
+          claude_args: |
+            --allowedTools "Skill,Task,mcp__github__get_*,mcp__github__list_*,mcp__github__search_*,Bash(gh api *),Bash(vale *),Bash(uv run mkdocs *),Bash(git tag *),Bash(git show *),Bash(git diff *),Bash(git log *)"
+
+      - name: Open the notes PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Only the notes surface is ever committed: the release pages and
+          # any vocabulary the Vale loop legitimately added.  An agent run
+          # that changed nothing (honest failure) opens no PR — the release
+          # stands with its interim body.
+          ACCEPT=".vale/styles/config/vocabularies/Base/accept.txt"
+          if ! git status --porcelain -- docs/releases "$ACCEPT" | grep -q .; then
+            echo "no notes changes produced — skipping PR; the release keeps its interim body"
+            exit 0
+          fi
+          BODY=.release-notes-pr-body.md
+          if [ ! -f "$BODY" ]; then
+            {
+              echo "Agent-drafted release notes for ${TAG} (the drafting run left no PR body; review the page against its inline evidence links)."
+              echo
+              echo "Refs: https://github.com/${REPO}/releases/tag/${TAG}"
+            } > "$BODY"
+          fi
+          BRANCH="release-notes/${TAG}"
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add docs/releases "$ACCEPT"
+          git commit -m "docs(releases): release notes for ${TAG}"
+          # Force: a re-dispatch for the same tag replaces the previous draft.
+          git push --force origin "HEAD:${BRANCH}"
+          gh pr create --base "$DEFAULT" --head "$BRANCH" \
+            --title "docs(releases): release notes for ${TAG}" \
+            --body-file "$BODY" \
+            || echo "PR for ${BRANCH} already exists — the force-push updated it"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,20 @@
+# Prerelease-ness is a property of the BRANCH, not of a dispatch flag (see
+# [tool.semantic_release.branches] in pyproject.toml): dispatching from `main`
+# cuts a stable release; dispatching from a short-lived `release/X.Y`
+# stabilisation branch cuts an rc by default, or the final stable X.Y.Z when
+# the `finalize` box is checked.  Every publish gate below derives from PSR's
+# own outputs (`is_prerelease`) and from tag ordering — never from a dispatch
+# input — so a mismatched dispatch cannot open a stable-only gate for an rc.
+# After any release cut from a `release/*` branch, the `merge-back` job merges
+# the branch back into `main`; without that, the tag is unreachable from
+# `main` and PSR deadlocks there ("already released" forever).
 name: Release
 
 on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force version bump type (empty = auto from commits). patch/minor/major override commit analysis. Ignored when pre-release box is checked and an rc series is already active — the revision is advanced automatically.'
+        description: 'Force version bump type (empty = auto from commits). patch/minor/major override commit analysis. Only valid on main — a release/X.Y branch has its target fixed at cut time.'
         type: choice
         default: ''
         options:
@@ -12,10 +22,10 @@ on:
           - patch
           - minor
           - major
-      prerelease:
-        description: 'Create a pre-release (rc channel — skips PyPI, catalog, registry, linux packages). Uncheck to cut a real release.'
+      finalize:
+        description: 'On a release/X.Y branch: cut the final stable X.Y.Z instead of the next rc. No effect on main, which always releases stable.'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -23,8 +33,13 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Per-branch buckets: a patch release off release/X.Y must not serialise
+    # behind a minor off main.  Cross-branch resources stay safe without a
+    # global bucket: PyPI/GitHub-release/registry writes are per-version, the
+    # marketplace push rebase-retries, docs deploys serialise in docs.yml, and
+    # the rolling Docker tags are ordering-gated below.
     concurrency:
-      group: release
+      group: release-${{ github.ref_name }}
       cancel-in-progress: false
 
     permissions:
@@ -39,49 +54,81 @@ jobs:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Detect active pre-release series
-        id: detect-rc
+      # The branch fixes the version target, so only two dispatch surfaces
+      # remain and each is guarded: `force` is a main-only override (on a
+      # release branch it would compound past the target fixed at cut time —
+      # the failure mode behind template#154), and any branch matching neither
+      # PSR branch group is rejected by PSR itself before anything publishes.
+      - name: Reject force bump on a release branch
+        if: startsWith(github.ref, 'refs/heads/release/') && inputs.force != ''
         run: |
-          latest_rc=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1 || true)
-          latest_stable=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
-          in_rc_series=false
-          if [ -n "$latest_rc" ]; then
-            rc_base="${latest_rc%-rc.*}"
-            # Active only when the rc's stable base is not yet tagged AND the
-            # series targets a version newer than the latest stable release. An
-            # rc whose base is <= the latest stable is an abandoned/superseded
-            # series (e.g. a v2.0.0-rc left behind when the project jumped to
-            # v3.x); it must not trigger the force=prerelease revision bump,
-            # which from a stable base produces <current>-rc.1 instead of a
-            # bumped version.
-            newest=$(printf '%s\n%s\n' "$rc_base" "${latest_stable:-v0.0.0}" | sort -V | tail -1)
-            if ! git tag --list | grep -qx "$rc_base" \
-               && [ "$newest" = "$rc_base" ] && [ "$rc_base" != "${latest_stable:-v0.0.0}" ]; then
-              in_rc_series=true
-              echo "rc_series_target=$rc_base" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-          echo "in_rc_series=$in_rc_series" >> "$GITHUB_OUTPUT"
-
-      - name: Compute effective PSR force
-        id: compute-force
-        run: |
-          force="${{ inputs.force }}"
-          prerelease="${{ inputs.prerelease }}"
-          in_rc_series="${{ steps.detect-rc.outputs.in_rc_series }}"
-          if [[ "$prerelease" == "true" && "$force" == "" && "$in_rc_series" == "true" ]]; then
-            echo "effective_force=prerelease" >> "$GITHUB_OUTPUT"
-          else
-            echo "effective_force=$force" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Reject force bump on active pre-release series
-        if: steps.detect-rc.outputs.in_rc_series == 'true' && inputs.prerelease == false && (inputs.force == 'patch' || inputs.force == 'minor' || inputs.force == 'major')
-        run: |
-          echo "::error::An active pre-release series is in progress targeting ${{ steps.detect-rc.outputs.rc_series_target }}."
-          echo "::error::force=patch/minor/major with prerelease=false applies an additional bump on top of the series target and will skip ${{ steps.detect-rc.outputs.rc_series_target }}."
-          echo "::error::To finalize the series as a stable release, dispatch with force='' and prerelease=false."
+          echo "::error::force=${{ inputs.force }} is not valid on ${{ github.ref_name }}: a release branch's version target is fixed at cut time."
+          echo "::error::Dispatch with force='' — commits on the branch advance the rc revision; check 'finalize' to cut the final stable."
           exit 1
+
+      # Advisory only (never blocks — the cut may be intentional, or belong on
+      # a release/X.Y branch cut from an earlier commit).  Surfaces both
+      # queryable quiescence signals the epic conventions record:
+      #   * the preferred milestone — a release-named milestone (X.Y) with
+      #     open issues means that version is not yet safe to cut; and
+      #   * the ships-atomically label — for each open epic it also counts
+      #     open native sub-issues, which may live in another repo, so a
+      #     cross-repo epic whose children are elsewhere stays visible.
+      # Every gh call is guarded so a failure or an unsupported endpoint
+      # degrades to no warning rather than failing the step under pipefail.
+      - name: Warn about open ships-atomically epics and release milestones
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # (1) Open ships-atomically epics, each with a count of still-open
+          #     children (native sub-issues — cross-repo aware).
+          epics=$(gh issue list --repo "$REPO" --label ships-atomically \
+            --state open --json number,title \
+            --jq '.[] | "\(.number)\t\(.title)"' 2>/dev/null || true)
+          if [ -n "$epics" ]; then
+            printf '%s\n' "$epics" | while IFS="$(printf '\t')" read -r num title; do
+              [ -n "$num" ] || continue
+              kids=$(gh api "repos/$REPO/issues/$num/sub_issues" \
+                --jq '[.[] | select(.state == "open")] | length' 2>/dev/null || echo '?')
+              echo "::warning::Open ships-atomically epic #$num ($title) — $kids open child issue(s). Releasing $REPO@main ships HEAD mid-story; consider a release/X.Y branch cut from before the epic started."
+            done || true
+          fi
+          # (2) The preferred signal: a release-named milestone (X.Y) that
+          #     still has open issues — that version is not yet quiescent.
+          milestones=$(gh api "repos/$REPO/milestones?state=open&per_page=100" \
+            --jq '.[] | select(.open_issues > 0) | select(.title | test("^[0-9]+[.][0-9]+$")) | "\(.title): \(.open_issues) open issue(s)"' 2>/dev/null || true)
+          if [ -n "$milestones" ]; then
+            printf '%s\n' "$milestones" | while IFS= read -r ms; do
+              [ -n "$ms" ] || continue
+              echo "::warning::Release milestone $ms — not yet safe to cut that version from a quiescent trunk."
+            done || true
+          fi
+
+      # PSR's CLI can force prerelease ON (--as-prerelease) but not OFF, so
+      # the final stable from a release branch needs a one-run config override:
+      # the same [tool.semantic_release] config with the release group's
+      # `prerelease` flipped to false.  Generated from pyproject.toml at run
+      # time (never committed — PSR stages only version files and assets), so
+      # it cannot drift from the real config.
+      - name: Prepare stable-finalize config override
+        id: psr-config
+        if: inputs.finalize && startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          python3 - <<'EOF'
+          import json
+          import tomllib
+
+          with open("pyproject.toml", "rb") as fh:
+              cfg = tomllib.load(fh)["tool"]["semantic_release"]
+          # Fails loudly (KeyError) if the branch groups were removed/renamed;
+          # silently inventing a group here would mask a broken config.
+          cfg["branches"]["release"]["prerelease"] = False
+          with open(".psr-finalize.json", "w") as fh:
+              json.dump({"semantic_release": cfg}, fh)
+          EOF
+          echo "config_file=.psr-finalize.json" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -98,9 +145,116 @@ jobs:
           github_token: ${{ secrets.RELEASE_TOKEN }}
           git_committer_name: "github-actions"
           git_committer_email: "actions@users.noreply.github.com"
-          force: ${{ steps.compute-force.outputs.effective_force }}
-          prerelease: ${{ inputs.prerelease }}
-          prerelease_token: rc
+          force: ${{ inputs.force }}
+          # Empty unless finalizing a release branch; "" means pyproject.toml.
+          config_file: ${{ steps.psr-config.outputs.config_file }}
+
+      # A release from an old series must not repoint rolling channels at
+      # older content: Docker `latest`/`vX`/`vX.Y`, the GitHub "latest
+      # release" pointer, the marketplace entry, and the MCP registry all
+      # follow ONLY when this release is the highest in the relevant series.
+      # Tags are complete here: full-depth checkout plus the tag PSR just cut.
+      - name: Determine channel ordering
+        id: ordering
+        if: steps.release.outputs.released == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.release.outputs.is_prerelease }}
+        run: |
+          is_latest=false
+          is_latest_major=false
+          is_latest_minor=false
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            ver="${TAG#v}"
+            major="${ver%%.*}"
+            minor="${ver%.*}"
+            stable=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+            if [ "$(printf '%s\n' "$stable" | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest=true
+            fi
+            if [ "$(printf '%s\n' "$stable" | grep -E "^v${major}\." | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest_major=true
+            fi
+            if [ "$(printf '%s\n' "$stable" | grep -E "^v${minor//./\\.}\." | sort -V | tail -1)" = "$TAG" ]; then
+              is_latest_minor=true
+            fi
+          fi
+          {
+            echo "is_latest=$is_latest"
+            echo "is_latest_major=$is_latest_major"
+            echo "is_latest_minor=$is_latest_minor"
+          } >> "$GITHUB_OUTPUT"
+
+      # Release-body contract (template#350, settled jointly with
+      # template#347): the body is a user-facing summary plus pointers — the
+      # docs site is canonical, and commit-level detail stays behind the
+      # compare link and CHANGELOG.md.  Composing the body here (overwriting
+      # PSR's default commit-list notes) makes it independent of the
+      # tag-to-tag commit range, so a stable that finalises an rc series gets
+      # the same body as any other release instead of an empty-range one.
+      # The compare link spans the cycle since the previous STABLE tag — one
+      # definition of "what belongs in this release" for stables and rcs
+      # alike.  Tags are complete here (see the ordering step above).
+      # NOTES-GENERATOR SEAM (template#347): consumed. The body written here
+      # is the at-release interim state; after the Release Notes workflow's
+      # agent-drafted docs/releases page merges, release-notes-publish.yml
+      # replaces the interim summary with the page's marked summary block and
+      # a deep link into the versioned docs/releases page, keeping the
+      # compare and CHANGELOG pointers. The closing line below doubles as the
+      # upgrade-once marker that workflow keys on — reword them together.
+      - name: Set release body (summary + docs pointers)
+        if: steps.release.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.release.outputs.is_prerelease }}
+          REPO: ${{ github.repository }}
+        run: |
+          ver="${TAG#v}"
+          minor="${ver%%-*}"
+          minor="${minor%.*}"
+          # Highest stable tag strictly below this release (series-aware via
+          # sort -V; empty on a project's very first release).
+          prev=$(
+            { git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                | grep -Fvx "$TAG"; echo "$TAG"; } \
+              | sort -V | awk -v t="$TAG" '$0 == t { print p; exit } { p = $0 }'
+          )
+          {
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              echo "Release candidate ${ver}: a branch-scoped stabilisation build for the upcoming v${minor} stable. Install it only to help test that release."
+              echo
+              # The stable's versioned docs publish when the stable ships;
+              # rcs deploy no docs, so point at the site root instead of a
+              # not-yet-existing /X.Y/ page.
+              echo "- Documentation: https://pvliesdonk.github.io/paperless-mcp/ (the v${minor} pages publish when the stable ships)"
+            else
+              echo "paperless-mcp ${ver}."
+              echo
+              echo "- Documentation: https://pvliesdonk.github.io/paperless-mcp/${minor}/"
+            fi
+            if [ -n "$prev" ]; then
+              echo "- All changes since ${prev}: https://github.com/${REPO}/compare/${prev}...${TAG}"
+            fi
+            echo "- Commit-level detail: [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)"
+            # Only a stable's body gets the notes-page promise: the Release
+            # Notes Publish workflow matches stable tags only, so an rc body
+            # would carry a pointer nothing ever fulfils.
+            if [ "$IS_PRERELEASE" != "true" ]; then
+              echo
+              echo "Release notes will move to a versioned notes page on the documentation site; until then, the links above carry the full change record."
+            fi
+          } > release-body.md
+          gh release edit "$TAG" --notes-file release-body.md
+
+      # GitHub auto-marks the newest non-prerelease as the repo's "latest
+      # release", which would repoint /releases/latest (and the versionless
+      # .deb/.rpm URLs) at a backport patch cut after a newer stable. Demote it.
+      - name: Keep the GitHub latest-release pointer ordered
+        if: steps.release.outputs.released == 'true' && steps.release.outputs.is_prerelease == 'false' && steps.ordering.outputs.is_latest == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ steps.release.outputs.tag }} --latest=false
 
       - name: Build package
         if: steps.release.outputs.released == 'true'
@@ -140,10 +294,19 @@ jobs:
       released: ${{ steps.release.outputs.released }}
       version: ${{ steps.release.outputs.version }}
       tag: ${{ steps.release.outputs.tag }}
+      # "true"/"false" from PSR itself — the single source the publish gates
+      # below derive from, so gate state can never desync from what PSR cut.
+      is_prerelease: ${{ steps.release.outputs.is_prerelease }}
+      is_latest: ${{ steps.ordering.outputs.is_latest }}
+      is_latest_major: ${{ steps.ordering.outputs.is_latest_major }}
+      is_latest_minor: ${{ steps.ordering.outputs.is_latest_minor }}
 
   publish-pypi:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # Every stable, including a backport patch from an old release/X.Y: PyPI
+    # versions are immutable and unordered, and installers pinned below a
+    # newer major are exactly who a backport serves.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -215,12 +378,18 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Rolling tags are ordering-gated (see the release job): a backport
+          # patch cut after a newer stable updates only the series tags it is
+          # actually the newest member of, and never `latest`.  An rc pushes
+          # its immutable version tag alone — the rolling `unstable` tag is
+          # retired now that rcs are rare, branch-scoped stabilisation builds
+          # ("run the latest code" is the `edge` tag, pushed per merge to main
+          # by the Unstable channel workflow).
           tags: |
             type=raw,value=v${{ steps.version.outputs.version }}
-            type=raw,value=latest,enable=${{ !inputs.prerelease }}
-            type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ !inputs.prerelease }}
-            type=raw,value=v${{ steps.version.outputs.major }},enable=${{ !inputs.prerelease }}
-            type=raw,value=unstable,enable=${{ inputs.prerelease }}
+            type=raw,value=latest,enable=${{ needs.release.outputs.is_latest == 'true' }}
+            type=raw,value=v${{ steps.version.outputs.minor }},enable=${{ needs.release.outputs.is_latest_minor == 'true' }}
+            type=raw,value=v${{ steps.version.outputs.major }},enable=${{ needs.release.outputs.is_latest_major == 'true' }}
           labels: |
             org.opencontainers.image.title=paperless-mcp
             org.opencontainers.image.description=Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields.
@@ -265,7 +434,7 @@ jobs:
 
   publish-linux-packages:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest
 
     permissions:
@@ -371,7 +540,9 @@ jobs:
   # than failing the release.
   publish-claude-plugin:
     needs: release
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # `is_latest` keeps the single marketplace entry ordered: a backport patch
+    # from an old series must not repoint the catalog at older content.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false' && needs.release.outputs.is_latest == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check plugin artifact exists at tag
@@ -470,7 +641,10 @@ jobs:
 
   publish-registry:
     needs: [release, publish-pypi, publish-docker]
-    if: needs.release.outputs.released == 'true' && !inputs.prerelease
+    # `is_latest` for the same reason as the marketplace: the registry entry
+    # is a discovery surface for the newest release; a backport's audience
+    # already holds pins and installs from PyPI or GitHub releases.
+    if: needs.release.outputs.released == 'true' && needs.release.outputs.is_prerelease == 'false' && needs.release.outputs.is_latest == 'true'
     runs-on: ubuntu-latest
 
     permissions:
@@ -481,7 +655,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: main
+          # The released ref, not a branch: the release commit — with the
+          # bumped server.json this job publishes — lives on whatever branch
+          # the release was cut from, and mid-cycle `main` may carry a
+          # different version entirely.
+          ref: ${{ needs.release.outputs.tag }}
           fetch-depth: 1
 
       - name: Install mcp-publisher
@@ -503,3 +681,54 @@ jobs:
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+  # After ANY release cut from a release/* branch, the branch merges back into
+  # the default branch.  This is not housekeeping but a hard requirement:
+  # with the new tag unreachable from main, PSR on main recomputes the same
+  # version from main's own history, finds the tag taken repo-globally, and
+  # reports "already released" forever — no later commit unblocks it.  The
+  # merge is the only reverse flow (it carries PSR's release commits; feature
+  # cherry-picks never come back), and it also keeps main's version metadata
+  # current so edge builds self-report a real version.  scripts/merge_back.sh
+  # resolves version-coupled files (pyproject.toml, changelog, PSR assets) to
+  # main's side — main is authoritative for current metadata; the tag
+  # preserves the branch's own state — and fails loudly on any other
+  # conflict, leaving a clean tree for a manual merge:
+  #   git checkout main && git merge --no-ff release/X.Y  (resolve, push)
+  merge-back:
+    needs: release
+    if: needs.release.outputs.released == 'true' && startsWith(github.ref, 'refs/heads/release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          # Same PAT that pushes the release commit; a plain GITHUB_TOKEN push
+          # would also suppress the CI/docs/edge workflows this merge should
+          # trigger on main.
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Merge release branch back into default branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+          TAG: ${{ needs.release.outputs.tag }}
+          DEFAULT: ${{ github.event.repository.default_branch }}
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@users.noreply.github.com"
+          # Concurrent pushes to main race with ours; redo the whole merge on
+          # a fresh tip rather than rebasing a merge commit.
+          for attempt in 1 2 3; do
+            git fetch origin "$BRANCH" "$DEFAULT"
+            git reset --hard "origin/$DEFAULT"
+            bash scripts/merge_back.sh "origin/$BRANCH" "$TAG"
+            if git push origin "HEAD:$DEFAULT"; then
+              exit 0
+            fi
+          done
+          echo "::error::could not push the merge-back of $BRANCH after 3 attempts; merge $BRANCH into $DEFAULT manually — until it lands, PSR cannot release from $DEFAULT"
+          exit 1

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,0 +1,110 @@
+# Rolling unstable channel (#351): every merge to `main` rebuilds the
+# container image under the fixed `edge` tag and packs an mcpb bundle as a
+# workflow artifact. No git tag, no GitHub release, no version bump, no
+# manifest churn — this channel answers "let me run the latest merged code"
+# without release machinery. Version-numbered pre-releases (rc) remain
+# release.yml's job, cut from short-lived release/X.Y stabilisation branches
+# and published only under their immutable vX.Y.Z-rc.N image tags (the
+# rc-fed rolling `unstable` tag is retired; `edge` is the one rolling
+# unstable tag, and one tag must have exactly one producer).
+name: Unstable channel
+
+on:
+  push:
+    branches: [main]
+  # Manual dispatch seeds or refreshes the channel without waiting for a
+  # merge (first-time setup, registry hiccup recovery).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only the newest commit matters for a rolling tag: superseded runs are
+# cancelled so an older build cannot finish after a newer one and leave
+# `edge` pointing at stale code.
+concurrency:
+  group: unstable-channel
+  cancel-in-progress: true
+
+jobs:
+  docker-edge:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # A single fixed tag. metadata-action stamps
+          # org.opencontainers.image.revision with the commit sha, so the
+          # exact commit behind `edge` is always readable from the image
+          # despite the channel carrying no version.
+          tags: |
+            type=raw,value=edge
+          labels: |
+            org.opencontainers.image.title=paperless-mcp
+            org.opencontainers.image.description=Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields.
+            org.opencontainers.image.vendor=pvliesdonk
+            io.modelcontextprotocol.server.name=io.github.pvliesdonk/paperless-mcp
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  mcpb-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Render/validate/pack/smoke live in the shared composite action
+      # (.github/actions/build-mcpb) — the same steps release.yml and the
+      # pre-release-check workflow run, so this path cannot drift from what
+      # a real release executes.
+      - name: Build and smoke-test mcpb bundle
+        uses: ./.github/actions/build-mcpb
+        with:
+          # Constant, versionless by design: 0.0.0-dev is valid semver (so
+          # `mcpb validate` accepts it), sorts below every real release (so
+          # an unstable bundle can never masquerade as an upgrade), and is
+          # already the pre-release-check workflow's proven default.
+          version: 0.0.0-dev
+
+      - name: Upload mcpb bundle artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: mcpb-bundle-edge
+          path: dist/paperless-mcp-*.mcpb
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ htmlcov/
 # MkDocs build output
 site/
 
-# Vale downloads style packages; retain only the tracked configuration/vocabulary.
+# Vale-synced style packages (downloaded by `vale sync`). Custom config
+# (vocabularies, ini overrides) under .vale/styles/config/ stays
+# versioned — sync never touches that subtree.
 .vale/styles/*
 !.vale/styles/config/
 
@@ -40,17 +42,17 @@ site/
 # --- Development / ecosystem ignores (don't ship)
 .mcpregistry_*
 .worktrees/
-.superpowers/
 docs/superpowers/
 # Everything under .claude/ is local EXCEPT skills/ — that subtree ships the
 # contributor-facing authoring skill(s), template-owned and re-rendered on
 # copier update (project additions live inside its DOMAIN-AUTHORING sentinel).
 .claude/*
 !.claude/skills/
-# Keep only the root client-local manifest ignored. Plugin manifests are release
-# assets and must remain tracked for clean-checkout version stamping.
-/.mcp.json
+# No trailing slash: `.mcp.json/` would match a *directory* of that name and
+# leave the actual file tracked.
+.mcp.json
 .repowise/
+.superpowers/
 
 # Editor-local config. Deliberately just this one — a contributor's choice of
 # editor is theirs, and this list is not meant to grow into a catalogue of

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,13 +28,22 @@ repos:
         pass_filenames: false
         args: [src/, tests/]
 
-      # Structural-health gate: strict ruff structural rules on changed lines
-      # only (diff vs origin/main), mirroring the CI `structure` job.
+      # Structural-health gate: strict ruff structural rules on CHANGED LINES
+      # ONLY, sharing scripts/structural_gate.sh with the CI `structure` job so
+      # the command cannot drift between the two. The script derives its
+      # compare branch (nearest of origin/main and origin/release/*, or the
+      # STRUCTURAL_GATE_BASE override), so a backport branch targeting
+      # release/X.Y is measured against that base rather than origin/main.
+      # Pre-push (not commit-time): a commit has no base to compare and may be
+      # partial; pre-push sees the full branch range CI checks.
       - id: structural-diff-gate
-        name: structural quality (diff vs origin/main)
-        entry: bash -c 'uv run diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --compare-branch=origin/main --fail-under=100'
+        name: structural quality (diff vs derived base)
+        entry: bash scripts/structural_gate.sh
         language: system
         pass_filenames: false
+        # Skip the hook when the push has no Python (with pass_filenames: false,
+        # pre-commit still uses `types` to decide whether to run at all). Mirrors
+        # the CI structure job's `HAS_PY` docs-only skip.
         types: [python]
         stages: [pre-push]
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -42,6 +42,20 @@ Vocab = Base
 # If tbhb/vale-ai-tells renames or removes the pinned release, `vale sync`
 # will fail permanently for this project. Periodically check
 # https://github.com/tbhb/vale-ai-tells/releases and bump the URL manually.
+#
+# THIS LINE IS THE SOURCE OF TRUTH for which packs exist, and three places
+# restate it by hand — change it and all three change with it:
+#   1. `BasedOnStyles` below. A style named there that `Packages` does not
+#      fetch makes vale exit 2 with `E100 [loadStyles]`.
+#   2. the `Cache Vale style packages` `path:` list in
+#      `.github/workflows/ci.yml`.
+#   3. the `for p in` list in `.pre-commit-config.yaml`'s `vale-sync` hook.
+#      A pack missing there is never seen as missing, so the hook never
+#      syncs and the `vale` hook right after it fails on packaging.
+# In the TEMPLATE repo, CI asserts these three plus its own workflow's cache
+# list against this line, so drift there fails loudly. This file is
+# `_skip_if_exists` (see above), so your copy is yours: nothing in this
+# project's CI checks that the three above still match a pack you add here.
 Packages = Google, proselint, write-good, https://github.com/tbhb/vale-ai-tells/releases/download/v1.9.0/ai-tells.zip
 
 [*.md]

--- a/.vale/styles/config/vocabularies/Base/accept.txt
+++ b/.vale/styles/config/vocabularies/Base/accept.txt
@@ -22,6 +22,7 @@ access_token
 id_token
 
 # --- Python / runtime ecosystem ---
+dataclass
 debugpy
 lockfile
 mypy
@@ -38,18 +39,26 @@ virtualenv
 
 # --- Operational / config jargon ---
 ADRs
+allowlist
+backports
 codecov
 config
 cron
+denylist
 deployer
 dev
 env
+hotfix
 repo
+ruleset
+rulesets
 systemd
 truthy
 uncommented
 uncommenting
 unprefixed
+upsert
+upserts
 validators
 
 # --- Diagnostics / observability ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+<!-- version list -->
+
 ## 0.1.0 - 2026-04-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,57 @@ Paperless-NGX document management over MCP: search, tag, upload, and read docume
 - Python 3.11+
 - `uv` for package management, `ruff` for linting/formatting (line length 88)
 - `hatchling` build backend
-- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
+- Conventional commits, one type from `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` — optionally scoped (`feat(search): ...`) and with `!` for a breaking change. `feat` cuts a minor release, `fix` and `perf` cut a patch, the rest cut none.
 - Google-style docstrings on all public functions
 - `logging.getLogger(__name__)` throughout, no `print()`
 - Type hints everywhere
 - Tests: `pytest` with fixtures in `tests/fixtures/`
 
+**Pull-request titles are enforced, not merely encouraged.** A squash merge
+takes the PR title as the commit subject, so CI's `PR Title` job checks it
+against the type list above and fails the `CI Success` aggregate when it does
+not match. This is not style policing: python-semantic-release parses that
+subject, and a type it does not recognise is dropped from `CHANGELOG.md`
+without a warning — no fallback heading, no entry at all. A commit that never
+reaches the changelog never reaches the release notes that link into it.
+
+Retitling is enough to clear a failure — the job reads the current title from
+the API, so re-running it after a retitle needs no push.
+
+**Reverts are the one accepted title with a caveat.** `Revert "..."`, the
+shape `git revert` and GitHub's revert button generate, passes: it is the
+ecosystem's convention, and Conventional Commits deliberately leaves reverts
+unspecified. But no python-semantic-release parser reads it — `angular` and
+`conventional` both fail on it — so such a commit does **not** reach
+`CHANGELOG.md`. The job says so with a warning annotation rather than letting
+you find out at release time. `revert: ORIGINAL SUBJECT` is the form that does
+reach the changelog. Either way the revert is narrated on the
+`docs/releases/` page, whose research runs off merged pull requests and linked
+issues rather than commit subjects.
+
+The accepted set lives in `pyproject.toml` under
+`[tool.semantic_release.commit_parser_options] allowed_tags`.
+`scripts/check_pr_title.py` and the list above are checked against it by
+`tests/test_commit_conventions.py`, so no one of the three can drift alone.
+
 The automated Claude review runs **only after CI passes** — if CI is red, no
 review is posted. Fix CI and push; the review runs on the next green run.
+
+## Breaking Changes and the `!` Marker
+
+Releases are cut by python-semantic-release from commit messages alone, so the `!` marker (or `BREAKING CHANGE:` footer) *is* the major-version decision — apply it deliberately, not by habit. A change is **breaking** only if it breaks one of two surfaces:
+
+- **Operator surface** — an environment variable, config file, CLI flag, deployment layout, or on-disk state format a human must change to upgrade.
+- **Public library interface** — anything importable from `paperless_mcp` that a downstream Python consumer uses. A mechanical guard for this tier is tracked at pvliesdonk/fastmcp-server-template#352.
+
+A change to the **MCP tool surface** (tool names, parameters, return schemas, adding or removing tools) is **not** breaking on its own. The LLM client is stateless and re-discovers the surface over the protocol on connect, so a server restart resolves it with no user action.
+
+Two refinements:
+
+1. **Re-discovery covers a tool's *shape*, not its *semantics*.** A tool that keeps its signature but changes what it does can still break operator automation, prompts, or skills. If only the MCP surface changed and the previous behaviour is still reachable (additive / dual-mode), the change is not breaking; if the old behaviour is gone, treat it as breaking even though the schema re-discovers cleanly.
+2. **Assess against the last stable release, not the previous commit.** A change to something introduced in the same unreleased range breaks nothing a user has, and does not earn a `!`. When a feature and its rework land in one release cycle, only the net effect on the released surface counts. Sanity-check any commit carrying `!` before it merges: if `git tag --contains` on the commit that introduced the surface comes back empty, the surface never shipped and the `!` is spurious.
+
+The two-part test: (1) does an operator or a library consumer of the last stable release have to change something? → breaking. (2) If only the MCP surface changed, is the previous behaviour still reachable? → not breaking; if it is gone, breaking.
 
 ## Hard PR Acceptance Gates
 
@@ -39,13 +82,11 @@ Every PR must pass **all** of the following before merge. Do not open or push a 
 
 5. **Structural quality (diff) passes** — new/changed code must introduce no new structural violations (complexity, too-many-*, security). Enforced on the diff only, so pre-existing code is never blocked. Run before pushing:
    ```bash
-   uv run diff-quality --violations=ruff.check \
-     --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
-     --compare-branch=origin/main --fail-under=100
+   bash scripts/structural_gate.sh
    ```
-   `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
+   The script derives its compare branch (nearest of `origin/main` and `origin/release/*`; override with `STRUCTURAL_GATE_BASE`) and runs `diff-quality --violations=ruff.check --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" --fail-under=100` against it. `# noqa: C901` (etc.) with a one-line justification is the escape hatch for genuinely irreducible new code.
 6. **Docs updated** — `README.md` and `docs/**` reflect any user-facing changes in the same commit
-7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version. The release workflow bumps them atomically via PSR; manual touches require updating all three.
+7. **Manifest version lockstep** — `server.json`, `.claude-plugin/plugin/.claude-plugin/plugin.json`, and `.claude-plugin/plugin/.mcp.json` must all carry the same version: the latest *stable* release. Stable releases bump them atomically via PSR; pre-releases deliberately leave them untouched, because the versions they name are only published for stable releases. Manual touches require updating all three.
 
 
 ## Pre-commit Hooks
@@ -55,7 +96,7 @@ This project ships a `.pre-commit-config.yaml` that runs ruff (check + format), 
 - **Install once per clone:** `uv run pre-commit install`.
 - **Run on demand before pushing:** `uv run pre-commit run --all-files`. A green run is a precondition for gates #2 and #3 above.
 
-- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs the command above automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — same command, same range, as long as your PR targets `main` (the hook hardcodes `origin/main`; CI compares against the PR's actual base branch).
+- **Structural gate runs at push time:** the `structural-diff-gate` hook (pre-push stage) runs `scripts/structural_gate.sh` automatically. `uv run pre-commit install` wires it via `default_install_hook_types`. A clean local push implies a clean CI `structure` job — CI runs the same script, pinning the compare branch to the PR's actual base, while the hook derives it (nearest of `origin/main` and `origin/release/*`), so backport branches targeting a release branch are measured against the right base locally too.
 
 - **Never bypass with `--no-verify`.** A failing hook means the same check will fail in CI; fix the underlying issue rather than silencing it.
 
@@ -114,7 +155,7 @@ Every issue, PR, and code change must consider documentation impact. Before clos
 - **`docs/design/`** — internal design specs and architecture decisions (the authoritative dev reference). Any new feature, changed behavior, or architectural decision must be reflected here. Not part of the published site.
 - **`README.md`** — user-facing documentation. New env vars, tools, resources, prompts, CLI flags, or configuration options must be documented here.
 - **`docs/` site pages** — the published documentation site. New or changed MCP tools/resources/prompts, new env vars, new installation methods or deployment options.
-- **`CHANGELOG.md`** — managed by semantic-release from conventional commits.
+- **`CHANGELOG.md`** — machine-generated audit trail: python-semantic-release inserts each release's version section at the `<!-- version list -->` insertion flag during the release workflow. Never hand-edit version sections or the flag line. If this project was generated before the flag existed, add the flag line to `CHANGELOG.md` once by hand — `tests/test_release_contract.py` fails with the exact line until it is present.
 - **Inline docstrings** — new or changed public API methods need accurate Google-style docstrings.
 
 **Rule: code without matching docs is incomplete.**
@@ -226,7 +267,7 @@ These sentinel blocks in `Dockerfile` are preserved across `copier update`. Add 
 
 ### Release manifest extension points
 
-`scripts/bump_manifests.py` bumps `server.json` and refreshes `uv.lock`'s self-version entry inside the release commit, so the tag never points at a manifest whose version lags it. These sentinel blocks in that script are preserved across `copier update`. Add bumps for this project's own version-coupled manifests (a Claude Code `plugin.json`, an `.mcp.json`, another lockstep JSON/TOML) inside them:
+`scripts/bump_manifests.py` bumps `server.json` and refreshes `uv.lock`'s self-version entry inside the release commit, so a stable tag never points at a manifest whose version lags it. On pre-release versions the script leaves `server.json` and the Claude plugin manifests at the last published stable — pre-releases skip PyPI and the MCP registry, so bumping those pins would make `main` name a version that does not exist anywhere (`tests/test_release_contract.py` asserts both behaviors). `uv.lock` is refreshed on every release, pre-release included, because it tracks `pyproject.toml` rather than a published artifact. These sentinel blocks in that script are preserved across `copier update`. Add bumps for this project's own version-coupled manifests (a Claude Code `plugin.json`, an `.mcp.json`, another lockstep JSON/TOML) inside them:
 
 - `# DOMAIN-MANIFESTS-HELPERS-START` / `-END` — module-level helpers (use `_load` / `_dump` for JSON so the byte format matches what `scripts/gen_config_surface.py` asserts)
 - `# DOMAIN-MANIFESTS-START` / `-END` — the calls, inside `main()`, where `version` is in scope
@@ -236,13 +277,74 @@ Every path bumped there must also appear in `pyproject.toml`'s `[tool.semantic_r
 
 ## Claude Code plugin channel
 
-`.claude-plugin/plugin/` ships this server as a Claude Code plugin: `.claude-plugin/plugin.json` (identity + version) and an exec-form `.mcp.json` that launches the released PyPI package with `uvx --from <pkg>==<version>`. Both manifests are version-coupled to the release — `scripts/bump_manifests.py` bumps them in the release commit and `[tool.semantic_release] assets` stages them, so the marketplace entry published by the release workflow always installs the version it points at (`tests/test_release_contract.py` gates that pairing). The `env` block in `.mcp.json`, the plugin README, and any `skills/` directories are project-owned content: the files are seeded once and never re-rendered by template updates. Values in `env` may reference plugin `userConfig` entries as `${user_config.<id>}` declared in `plugin.json` — exec-form fields only; shell-form command strings reject the substitution.
+`.claude-plugin/plugin/` ships this server as a Claude Code plugin: `.claude-plugin/plugin.json` (identity + version) and an exec-form `.mcp.json` that launches the released PyPI package with `uvx --from <pkg>==<version>`. Both manifests are version-coupled to the *stable* release stream — `scripts/bump_manifests.py` bumps them in stable release commits and `[tool.semantic_release] assets` stages them, so the marketplace entry published by the release workflow always installs the version it points at. Pre-releases never reach PyPI, so on pre-release runs the script leaves both files at the last published stable rather than pinning a version `uvx` cannot resolve (`tests/test_release_contract.py` gates the assets/script pairing and this skip). The `env` block in `.mcp.json`, the plugin README, and any `skills/` directories are project-owned content: the files are seeded once and never re-rendered by template updates. Values in `env` may reference plugin `userConfig` entries as `${user_config.<id>}` declared in `plugin.json` — exec-form fields only; shell-form command strings reject the substitution.
 
 To generate the plugin's configuration screen from the config surface instead of hand-editing it, declare a `files:` pair in `config-presentation.domain.yml`: the plugin.json path with `kind: claude-plugin-user-config` and a `fields:` map (same field specs as the mcpb screen above), plus the `.mcp.json` path with `kind: claude-plugin-env` and `fields_from:` naming the first entry. One fields map then drives both the `userConfig` object and the `${user_config.<id>}` env wiring, and `scripts/gen_config_surface.py --check` gates the pair against drift.
+
+## Public import surface guard
+
+`tests/test_import_surface.py` (template-owned, re-rendered on template updates) asserts the set of public names importable from the `paperless_mcp` package root against the project-owned snapshot `tests/public_import_surface.txt` (seeded once, never re-rendered by template updates — yours). The surface is enumerated in a fresh interpreter — every non-underscore name in `dir(package)` or `__all__` that resolves via `getattr` — so lazy `__getattr__` re-exports count, incidental submodule imports from earlier tests do not, and a root holding only a docstring and `__version__` has an empty surface. When the test fails:
+
+- **A name disappeared** — that is a breaking change to the public library interface. Either restore the name, or regenerate the snapshot (`uv run python tests/test_import_surface.py --update`) **and** mark the commit/PR breaking (`feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy's public-library-interface tier (pvliesdonk/fastmcp-server-template#342).
+- **A name appeared** — not breaking; regenerate the snapshot and commit it alongside the change, so the snapshot diff stays the reviewable record of every surface change.
+
+The guard covers the package root only — submodule paths, env vars, and CLI flags are out of its scope.
 
 ## Pre-release artifact smoke test
 
 The `Pre-release check` workflow (Actions tab, `workflow_dispatch`) builds and validates the mcpb bundle from any branch at a caller-supplied version (default `0.0.0-dev`), uploads it as a workflow artifact for manual install testing, and can optionally attach it to a deletable `v<version>-rc` pre-release. It runs the exact same steps a real release runs — both call the shared `.github/actions/build-mcpb` composite — so a green pre-release check means the release path's bundle build is green too. Project-specific artifact assertions (extra bundles, plugin manifests) belong in `packaging/pre-release-checks.sh` — an executable script the workflow runs when present, with `VERSION` and `BUNDLE` exported; the file is project-owned, and template updates never touch it.
+
+## Release model
+
+`main` is trunk. Everything merges there, and **merging is not releasing**: a merge feeds the rolling `edge` channel (next section) and nothing else. A release is a separate, deliberate event — dispatching the Release workflow — and the sections below say when and from where.
+
+**The default release path is trunk.** When a release is wanted and trunk is quiescent (no atomic epic mid-flight — the cut criterion below), dispatch Release on `main`. It cuts a stable from HEAD: no branch, no ceremony. Most releases should look like this.
+
+**The cut criterion.** An epic that ships atomically makes trunk unreleasable while it is open: releasing `main` ships HEAD, mid-story. Judge quiescence from the queryable signal the epic conventions record (see CONTRIBUTING.md's Epics section): preferably the **release milestone** — safe to cut means no open issues in the target release's milestone — with the **`ships-atomically` label** as the fallback when no milestone names a release yet. An open atomic epic with unclosed children means either release from a commit before the epic started (a `release/X.Y` branch cut from that commit) or wait. The Release workflow's advisory step surfaces both signals on every `main` dispatch — a release-named milestone (`X.Y`) that still has open issues, and open `ships-atomically` epics (each with a count of its native sub-issues, so a cross-repo epic whose children live elsewhere stays visible); it warns and never blocks, because the cut may still be intentional.
+
+**The `release/X.Y` branch is the exception tool**, for exactly two cases:
+
+1. **Dirty trunk at cut time** — trunk carries unfinished work that must be excluded from the release. Cut the branch from the last quiescent commit behind HEAD, stabilise there (rcs), and finalize the stable.
+2. **Patching a shipped release** — an already-released version needs a fix while `main` has moved on past it. The branch does not need to exist in advance: create it retroactively from the tag (`git branch release/X.Y vX.Y.Z`), land the fix, release.
+
+Fixes flow trunk → branch only: land on `main` first, cherry-pick to the branch. The automated release merge-back (see the release machinery section below) is the single reverse flow — it carries PSR's release commits, never features.
+
+**Branching cannot defer a structural refactor.** A refactor that changes existing behaviour makes every later cherry-pick across it conflict-prone, so a stabilisation branch buys no room for one. Land structural refactors early in a cycle, far from the next cut — not late, when a branch is about to be needed.
+
+**Cadence: value-triggered, not time-boxed.** No fixed release train — a calendar cadence is wrong for a low-traffic project and adds nothing to a busy one. Release when unreleased user-visible work (features, fixes, and especially security patches) has accumulated, and never hold a release hostage to unfinished work: excluding that work is exactly what the branch tool is for. The failure mode to avoid is drift — weeks of unreleased commits held behind one open epic.
+
+**The three channels and their promises:**
+
+| Channel | Identity | Promise |
+|---|---|---|
+| `edge` | none — the commit is the identity | the newest merged code, rebuilt on every merge to `main`; rolling and disposable |
+| rc | `vX.Y.Z-rc.N`, target fixed at cut time | a stabilisation step toward exactly that version, cut only from `release/X.Y` (a fresh stabilisation branch starts at `X.Y.0-rc.1`) |
+| stable | `vX.Y.Z` | a quiescent-trunk release (the default) or the promotion of a stabilisation branch (`finalize`) |
+
+An rc is not "the latest build with a version number" — that job belongs to `edge`, which costs one build-and-push and leaves no tag, release, or version bump behind. Cut rcs only when genuinely stabilising a specific release.
+
+## Unstable channel (rolling `edge` image)
+
+The `Unstable channel` workflow (`.github/workflows/unstable.yml`) runs on every push to `main` (plus manual dispatch for seeding) and rebuilds two artifacts from that commit: the container image, pushed to `ghcr.io/pvliesdonk/paperless-mcp:edge` — a fixed rolling tag whose contents each merge replaces — and an mcpb bundle built through the same shared `.github/actions/build-mcpb` composite the release path uses, uploaded as the `mcpb-bundle-edge` workflow artifact at the constant version `0.0.0-dev`. The channel is deliberately versionless: no git tag, no GitHub release, no version bump, no manifest change. "Run the latest merged code" costs one build-and-push and leaves nothing behind; the image's `org.opencontainers.image.revision` label carries the exact commit. The docs site's rolling `unstable` version deploys from the same trigger (`docs.yml`), so it tracks merged code the way `edge` does. Cutting a version-numbered pre-release (rc) remains `release.yml`'s job, from a `release/X.Y` branch (see the release machinery section below); rc images ship only under their immutable `vX.Y.Z-rc.N` tags — `edge` is the sole rolling unstable tag.
+
+## Release machinery (branches, rcs, merge-back)
+
+Prerelease-ness is a property of the **branch**, not of a dispatch flag: `[tool.semantic_release.branches]` maps `main` to stable releases and `release/.*` to rc pre-releases (token `rc`), and every publish gate in `release.yml` derives from PSR's own outputs (`is_prerelease`, tag ordering) — there is no pre-release checkbox to desync. Dispatching Release on `main` cuts a stable; on a short-lived `release/X.Y` stabilisation branch it cuts the next rc, or the final stable `X.Y.Z` when the `finalize` input is checked (implemented as a one-run generated config override, because PSR's CLI can force prerelease on but not off). The `force` input is main-only — a release branch's target is fixed at cut time. Branches matching neither group cannot release; PSR refuses them.
+
+Rolling channels are ordering-aware: Docker `latest`/`vX`/`vX.Y`, the GitHub latest-release pointer, the docs `latest` alias, the marketplace entry, and the registry entry only follow a release that is the newest in the relevant series, so a backport patch cut from an old `release/X.Y` never repoints them backwards.
+
+**After any release cut from a `release/*` branch, the branch must merge back into `main`.** The `merge-back` job does this automatically via `scripts/merge_back.sh` (version-coupled files resolve to `main`'s side; real conflicts fail loudly for a manual `git merge --no-ff release/X.Y`). This is a hard requirement, not hygiene: with the release tag unreachable from `main`, PSR recomputes the same version from `main`'s own history, finds the tag taken repo-globally, and reports "already released" forever. When to cut a branch at all — and the default of releasing from a quiescent trunk without one — is the [release model](#release-model) above, not machinery.
+
+<!-- TEMPLATE-TRACKING-START -->
+## Release notes pages
+
+`docs/releases/` is the canonical human-facing release narrative: one page per minor series, patch releases appending a dated section to their series page. The GitHub release body is a summary plus a deep link to the page, and `CHANGELOG.md` stays machine-written — never move narrative prose into it. After every stable release, the **Release Notes** workflow has an agent research the release range through the GitHub API (linked issues and PRs, never commit subjects) and open a PR adding or extending the page; the `writing-release-notes` skill (`.claude/skills/writing-release-notes/SKILL.md`) is the contract it follows. Notes pages always land on `main` via that PR — never by direct push, and never on a `release/*` branch.
+
+Two rules for working with these PRs:
+
+- **The evidence contract governs the page.** Every causal claim must trace to a linked issue or PR; no evidence, no narrative. Review a notes PR as an evidence check — follow the links and verify they support the claims — not as a prose polish; Vale (including the `ai-tells` pack) already gated the prose.
+- **Merging is what publishes.** On merge, the **Release Notes Publish** workflow upgrades the release body from the page's marked summary block and redeploys the minor's versioned docs so the deep link resolves. Notes PRs are tooling-authored and need no separate issue (same class as Renovate bumps).
+<!-- TEMPLATE-TRACKING-END -->
 
 ## Tool Registration Checklist
 
@@ -261,6 +363,10 @@ Every MCP tool you register must carry the full set of metadata below — not ju
 
 For services that talk to a remote upstream (e.g. paperless, an HTTP API), wire the upstream version inside the `DOMAIN-UPSTREAM-START` / `DOMAIN-UPSTREAM-END` sentinel in `src/paperless_mcp/server.py`. Pass `upstream_version=` (a zero-arg callable returning a dict / str / None) and optionally `upstream_label="<service>"` (default `"upstream"`). The simplest pattern is a module-level upstream client (typically constructed from env vars at import time) whose version method is referenced from the callable — `CurrentContext()` is a FastMCP DI marker that only resolves inside parameter defaults, so it cannot be called directly from a zero-arg provider. The block is preserved across `copier update`.
 
+## Repository protection (rulesets)
+
+`.github/rulesets/*.json` are the source of truth for this repository's branch and tag rulesets — required PRs + the `CI Success` check on `main` and `release/*`, deletion/force-push protection for `v*` tags — and `bootstrap.yml` applies them (upsert by name) on pushes touching those files and on manual dispatch. Never adjust protection in the GitHub UI: the next bootstrap run resets it to the checked-in state. Change the JSON files instead. The release pipeline's `RELEASE_TOKEN` (a repository admin's PAT) bypasses these rules **by design** via the admin-role bypass entry — PSR's release commit + tag push and the merge-back to `main` are direct pushes. Posture and bypass model: `docs/deployment/repository-protection.md`.
+
 <!-- TEMPLATE-TRACKING-START -->
 ## Shared Infrastructure
 
@@ -274,6 +380,8 @@ Fixes and improvements to shared code land in those repos and propagate here via
 ## Contributing fixes upstream
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the three-tier routing (library to `fastmcp-pvl-core`, template to `fastmcp-server-template`, domain to this repo), the issue/PR discipline, and the uncertainty rule. CONTRIBUTING.md is the single source; this section is a pointer.
+
+The `authoring-issues-prs` skill (`.claude/skills/authoring-issues-prs/SKILL.md`) fires when filing issues or PRs: it walks the routing, picks the issue form, and performs the follow-up steps forms cannot (native sub-issue links for epics, the release milestone or `ships-atomically` label). The skill is template-owned and re-rendered on `copier update`; project-specific authoring conventions belong inside its `DOMAIN-AUTHORING` sentinel block.
 
 If a conflict marker appears in a copier-update bot PR, the conflict itself often signals a template bug — investigate whether the template's version needs fixing before resolving locally.
 <!-- TEMPLATE-TRACKING-END -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,19 @@ Use the issue templates in `.github/ISSUE_TEMPLATE/`:
 
 - **Bug report** — something isn't working as expected.
 - **Feature request** — a new capability or enhancement.
+- **Epic** — a multi-feature effort that ships as one user-facing story.
+  See [Epics](#epics) below.
 - **Decay / structural debt** — refactor-later observations.
 - **Question / support** — questions and support requests.
+
+Before filing, search the target repo's existing issues — open **and**
+closed — for the same observation. If it is already on file, comment there
+rather than opening a duplicate.
+
+The `authoring-issues-prs` skill (`.claude/skills/authoring-issues-prs/`)
+walks this guide's routing and filing procedure and performs the follow-up
+steps issue forms cannot (sub-issue links, milestones). It points back at
+this file; this file stays the single source of the rules.
 
 ### Observation, not work order
 
@@ -55,6 +66,35 @@ a separate issue for it.
 | An "Additional context" section that introduces new problems | Open a separate issue |
 | Implementation steps (a numbered list of code changes) | Remove entirely |
 
+### Epics
+
+An epic is not just a bigger issue. It is the unit that answers two
+questions nothing else answers: **what story does this tell a user**, and
+**does it ship as a whole**. File one with the Epic form and:
+
+- **Write "What changes for the user" at epic creation**, before any code
+  exists. It becomes the release-notes highlight for the whole epic, so the
+  release editor verifies it against what landed instead of reconstructing
+  intent from merged PRs.
+- **Link children as native GitHub sub-issues, not markdown task lists.**
+  Sub-issues make the grouping queryable (parent, children, and progress
+  are API fields); a checklist is prose. Issue forms cannot create the link
+  at filing time — use the issue sidebar ("Create sub-issue" / "Add
+  existing issue") or the sub-issues API after filing. The
+  `authoring-issues-prs` skill performs this mechanically.
+- **If the epic ships atomically** (no release may be cut mid-epic), make
+  that queryable too. Preferred: assign the epic and its children to the
+  **milestone** named for the target release — "safe to cut" then reduces
+  to "no open issues in that milestone". Milestones are per-repo and
+  one-per-issue; for a cross-repo epic the milestone lives in the repo
+  where the release is cut. Fallback: apply the **`ships-atomically`
+  label** when no target release is named yet, or in the repos of a
+  cross-repo epic that do not cut the release. The form's yes/no field
+  records intent; only the milestone or label is what release tooling can
+  query.
+
+Existing epics tracked as hand-written checklists need no migration.
+
 ## Pull requests
 
 Every PR must have at least one associated issue. If the work has no issue
@@ -64,6 +104,13 @@ PR may close multiple issues (`Closes #A, closes #B`); the rule is "no orphan
 PRs", not "one PR per issue". Trivial exceptions: pure typo fixes and
 automated dependency bumps (Renovate) may skip the issue.
 
+Mark a commit breaking (`feat!:` / `BREAKING CHANGE:`) only under the
+breaking-change policy in `CLAUDE.md`: the change must break the operator
+surface (env var, config file, CLI flag, deployment layout, on-disk state)
+or the public library interface, assessed against the **last stable
+release**, not the previous commit. MCP tool-surface changes are not
+breaking on their own.
+
 State what the PR deliberately does **not** do, with each deferral's tracking
 issue. A change that says what it left out is easier to trust than one that
 appears to have found nothing.
@@ -71,6 +118,17 @@ appears to have found nothing.
 Run a local code-review pass on the cumulative diff before `gh pr create`.
 Code without matching docs is incomplete; check `README.md`, the `docs/`
 site, `docs/design/`, and inline docstrings.
+
+## Releases
+
+Merging is not releasing. When a release is cut, and from where, is
+governed by the release model in `CLAUDE.md`: releases normally come
+straight from a quiescent trunk, and a short-lived `release/X.Y` branch
+is the exception tool for excluding unfinished work or patching a
+shipped release. The ships-atomically signal recorded on epics
+(milestone preferred, label fallback; see [Epics](#epics)) is the input
+that judgement consumes: an open atomic epic with unclosed children
+means the release comes from before it started, or waits.
 
 ## Where to send fixes
 

--- a/FORKING.md
+++ b/FORKING.md
@@ -28,7 +28,8 @@ This removes the link copier uses to reattach. The weekly cron that ran
 ```bash
 rm -f .github/workflows/copier-update.yml \
       .github/workflows/claude.yml \
-      .github/workflows/claude-code-review.yml
+      .github/workflows/claude-code-review.yml \
+      .github/workflows/release-notes.yml
 rm -f scripts/copier_update_aggregator.py
 rm -rf scripts/copier_update_prompts
 ```
@@ -37,13 +38,20 @@ What this removes and why:
 
 - `copier-update.yml` — template-update automation; meaningless once detached.
 - `claude.yml`, `claude-code-review.yml` — fleet review-bot wiring.
+- `release-notes.yml` — the Claude-agent release-notes drafter (same
+  `CLAUDE_CODE_OAUTH_TOKEN` dependency as the review wiring). Keep it
+  instead if your fork keeps that secret and wants agent-drafted notes.
 - `scripts/copier_update_aggregator.py`, `scripts/copier_update_prompts/` —
   the orchestration that only `copier-update.yml` invoked; dead weight once
   that workflow is gone.
 
 **Keep** your own CI and release workflows: `ci.yml`, `codeql.yml`,
-`coverage-status.yml`, `docs.yml`, and `release.yml`. (`release.yml` still needs
-the `RELEASE_TOKEN` secret; only its `copier-update` justification is gone.)
+`coverage-status.yml`, `docs.yml`, `release.yml`, and
+`release-notes-publish.yml`. (`release.yml` still needs the `RELEASE_TOKEN`
+secret; only its `copier-update` justification is gone.
+`release-notes-publish.yml` is deterministic — no Claude dependency — and
+still publishes any `docs/releases/` page you write by hand: it upgrades the
+matching release body and redeploys the minor's versioned docs on merge.)
 
 ## Step 3 — Scrub template-tracking guidance from `CLAUDE.md`
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ uv sync --all-extras --all-groups
 docker pull ghcr.io/pvliesdonk/paperless-mcp:latest
 ```
 
+To run the newest merged code instead of the newest release, use the rolling `edge` tag. It is rebuilt on every merge to `main` and carries no version identity. See [Image tags](docs/deployment/docker.md#image-tags) for the full tag list.
+
+```bash
+docker pull ghcr.io/pvliesdonk/paperless-mcp:edge
+```
+
 A `compose.yml` ships at the repo root as a starting point. Copy `.env.example` to `.env`, edit, and `docker compose up -d`.
 
 To attach a remote Python debugger (development only; the protocol is unauthenticated), see [Remote debugging](docs/deployment/docker.md#remote-debugging).
@@ -80,6 +86,18 @@ mcpb install paperless-mcp-<version>.mcpb
 Claude Desktop prompts for required env vars via a GUI wizard, with no manual JSON editing needed.
 
 For manual Claude Desktop configuration and setup options, see [Claude Desktop deployment](docs/deployment/claude-desktop.md).
+
+## Release channels
+
+Artifacts ship on three channels. Each row lists exactly what that channel publishes.
+
+| Channel | Version identity | Artifacts |
+|---|---|---|
+| `edge` (rolling) | None; the commit is the identity | Docker image `:edge` rebuilt on every merge to `main`; `.mcpb` bundle as the `mcpb-bundle-edge` workflow artifact; rolling `unstable` docs version. It leaves no git tag, GitHub release, or PyPI entry behind. |
+| Pre-release | `vX.Y.Z-rc.N`, cut from a `release/X.Y` branch | GitHub release with wheels, `sdist`, `.mcpb` bundle, and SBOM attached; Docker image under its immutable `vX.Y.Z-rc.N` tag only. Skips PyPI, `.deb`/`.rpm` packages, the plugin marketplace, the MCP registry, and the docs deploy. |
+| Stable | `vX.Y.Z` | Everything: PyPI, Docker (version tag plus ordering-aware `latest` / `vX` / `vX.Y`), `.deb`/`.rpm`, GitHub release assets (wheels, `sdist`, `.mcpb` bundle, SBOM), plugin marketplace and MCP registry entries (when the release is the newest stable), versioned docs with an ordering-aware `latest` alias. |
+
+The PyPI split is deliberate: `edge` and pre-release builds never reach PyPI, where every ordinary installer would see them. A pre-release's wheels are still attached to its GitHub release and installable by URL for anyone who opts in. Rolling pointers are ordering-aware, so a patch release cut from an old `release/X.Y` branch never moves `latest`-style tags back to older content. See [Release process](docs/deployment/release-process.md) for the full model.
 
 ## Quick start
 
@@ -276,9 +294,9 @@ CI workflows reference three repository secrets. Configure them via **Settings â
 
 | Secret | Used by | How to generate |
 |---|---|---|
-| `RELEASE_TOKEN` | `release.yml`, `copier-update.yml`, `renovate.yml`, `bootstrap.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write`, `pull_requests: write`, and `administration: write` (bootstrap sets branch protection + auto-merge). Scoped to this repo. |
+| `RELEASE_TOKEN` | `release.yml`, `release-notes.yml`, `copier-update.yml`, `renovate.yml`, `bootstrap.yml` | Fine-grained PAT at <https://github.com/settings/personal-access-tokens/new> with `contents: write`, `pull_requests: write`, and `administration: write` (bootstrap applies the repository rulesets + auto-merge). Must belong to a repository admin: the shipped rulesets grant bypass to the admin role, and the release workflow's direct pushes rely on it. Scoped to this repo. |
 | `CODECOV_TOKEN` | `ci.yml` | <https://codecov.io>: sign in with GitHub and add the repo. The upload token is on its settings page. |
-| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml` | Run `claude setup-token` locally and paste the result. |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `claude.yml`, `claude-code-review.yml`, `release-notes.yml` | Run `claude setup-token` locally and paste the result. |
 
 ```bash
 gh secret set RELEASE_TOKEN
@@ -288,9 +306,11 @@ gh secret set CLAUDE_CODE_OAUTH_TOKEN
 
 > Dependency updates are handled by **Renovate** (`renovate.yml`), which reuses
 > `RELEASE_TOKEN`. It maintains `uv.lock` and auto-merges patch/minor bumps once
-> the `CI Success` check is green; `bootstrap.yml` enables auto-merge and branch
-> protection on first push. GitHub Actions are updated in the copier template
-> and arrive via `copier update`, not per-repo.
+> the `CI Success` check is green; `bootstrap.yml` enables auto-merge and applies
+> the repository rulesets (`.github/rulesets/`) on first push. See
+> [Repository Protection](docs/deployment/repository-protection.md) for the
+> per-branch posture and bypass model. GitHub Actions are updated in the copier
+> template and arrive via `copier update`, not per-repo.
 
 `GITHUB_TOKEN` is auto-provided; no action needed.
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -8,6 +8,22 @@ docker compose up -d
 
 The server listens on port 8000 with HTTP transport by default.
 
+## Image tags
+
+| Tag | Contents | Updated by |
+|-----|----------|------------|
+| `latest` | Newest stable release | Each stable release that is newest across all series |
+| `vX.Y.Z` | That exact release (pre-releases included, as `vX.Y.Z-rc.N`) | Never (immutable) |
+| `vX.Y`, `vX` | Newest stable release in that series | Each stable release that is newest in its series |
+| `edge` | Newest commit on `main` | Every merge to `main` |
+
+Rolling tags are ordering-aware: a patch release cut from an old `release/X.Y` branch after a newer stable has shipped updates its own series tags but never `latest`. A pre-release pushes only its immutable `vX.Y.Z-rc.N` tag. To run the latest merged code, use `edge`, which follows `main` continuously and carries no version identity. To find the commit behind an `edge` image, read its `org.opencontainers.image.revision` label:
+
+```bash
+docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+  ghcr.io/pvliesdonk/paperless-mcp:edge
+```
+
 ## Environment variables
 
 | Variable | Default | Description |

--- a/docs/deployment/release-process.md
+++ b/docs/deployment/release-process.md
@@ -1,0 +1,95 @@
+# Release Process
+
+`main` is trunk: every change merges there, and merging is not releasing.
+A merge feeds the rolling `edge` channel and nothing else. A release is a
+separate, deliberate event, cut by dispatching the **Release** workflow,
+and this page describes what each kind of release publishes and where
+releases come from.
+
+## Channels
+
+| Channel | Version identity | What it promises |
+|---|---|---|
+| `edge` | None; the commit is the identity | The newest merged code. Every merge to `main` rebuilds the rolling Docker tag plus an `.mcpb` bundle workflow artifact, and the rolling `unstable` docs version deploys from the same trigger. It leaves no git tag, GitHub release, or PyPI entry behind. |
+| Pre-release | `vX.Y.Z-rc.N`, fixed at cut time | A stabilisation step toward exactly that version, cut from a `release/X.Y` branch. Publishes a GitHub release with wheels, `sdist`, `.mcpb` bundle, and SBOM attached, plus a Docker image under its immutable version tag. Skips PyPI, `.deb`/`.rpm` packages, the marketplace and registry entries, and the docs deploy. |
+| Stable | `vX.Y.Z` | The full artifact set: PyPI, Docker, Linux packages, GitHub release assets (wheels, `sdist`, `.mcpb` bundle, SBOM), marketplace and registry entries, versioned docs. |
+
+Pre-release and `edge` builds never reach PyPI: PyPI is where every
+ordinary installer looks, and unstable builds do not belong in front of
+it. A pre-release's wheels are still attached to its
+[GitHub release](https://github.com/pvliesdonk/paperless-mcp/releases)
+and installable by URL for anyone who opts in.
+
+Rolling pointers are ordering-aware. The Docker `latest`, `vX`, and `vX.Y`
+tags, the GitHub latest-release pointer, the docs `latest` alias, and the
+marketplace and registry entries follow a release only when it is the
+newest in the relevant series, so a patch release cut from an old
+`release/X.Y` branch never moves them back to older content. See
+[Image tags](docker.md#image-tags) for the Docker tag list.
+
+## Releasing from trunk
+
+The default release path is trunk. When trunk is quiescent (no epic that
+must ship whole is mid-flight), dispatching Release on `main` cuts a
+stable from the head commit: no branch, no ceremony. The workflow prints
+an advisory warning when a release-named milestone still has open issues,
+or when an open `ships-atomically` epic shows work in flight. It counts the
+epic's native sub-issues, which may live in another repository, so a
+cross-repo epic stays visible. Either way the warning never blocks, since
+the cut may still be intentional.
+
+## Stabilisation branches
+
+A short-lived `release/X.Y` branch is the exception tool, for two cases:
+
+1. **Trunk carries unfinished work** that the release must exclude. The
+   branch is cut from the last quiescent commit behind the head, release candidates are
+   cut there while fixes land, and the `finalize` dispatch input cuts the
+   final stable `X.Y.Z`.
+2. **A shipped release needs a patch** while `main` has moved on. The
+   branch can be created retroactively from the release tag, so no branch
+   needs to exist in advance of the need.
+
+Fixes flow from trunk to the branch: they land on `main` first and are
+cherry-picked over. After any release cut from a `release/X.Y` branch, an
+automated merge-back job merges the branch into `main`; that merge is the
+single reverse flow, and it carries only the release machinery's version
+commits, never features.
+
+Release branches carry shipped releases, so they get the same protection
+as `main`: pull requests plus green CI, applied by the shipped rulesets.
+See [Repository Protection](repository-protection.md).
+
+## Where to read about a release
+
+Each release is described in three places with distinct jobs:
+
+- **The GitHub release body** carries a short user-facing summary and a
+  link to the release's notes page on this site. The body is a pointer,
+  not the record.
+- **The release notes pages on this docs site** are the canonical
+  human-facing narrative of what changed and why it matters.
+- **`CHANGELOG.md`** in the repository is the machine-written,
+  commit-level audit trail, generated from conventional commits by the
+  release tooling.
+
+### How the notes pages are produced
+
+The pages under [Release Notes](../releases/index.md) cover one minor
+series each; a patch release adds a dated section to its series page.
+After every stable release, the **Release Notes** workflow drafts the
+page: an agent researches the release range through the GitHub API (the
+linked issues and pull requests, not commit subjects) and opens a pull
+request against `main`. Every causal claim in a page must cite a linked
+issue or pull request. The drafting agent runs the same prose lint as the
+rest of this site while it writes, and the notes pull request's own CI
+enforces it: the `vale` job must pass before the pull request can merge,
+the same gate every change to this site clears.
+
+A maintainer merge is the publication step. Nothing lands on the site
+without review, and until the merge the release keeps the short interim
+body the release workflow wrote; a failed or unconvincing draft never
+blocks or alters a release. On merge, the **Release Notes Publish**
+workflow updates the GitHub release body from the page's summary and
+redeploys that minor's versioned docs so the body's deep link resolves.
+Later hand edits to a merged page redeploy the docs the same way.

--- a/docs/deployment/repository-protection.md
+++ b/docs/deployment/repository-protection.md
@@ -1,0 +1,110 @@
+# Repository Protection
+
+The template ships GitHub repository rulesets that gate the branches a
+release can ship from. The rules live as JSON files in `.github/rulesets/`
+and the `bootstrap.yml` workflow applies them, so the effective protection
+state is checked in, reviewed, and re-applied rather than clicked together
+in the UI and forgotten.
+
+## What ships
+
+Three rulesets, one file each:
+
+| Ruleset | Targets | Rules |
+|---|---|---|
+| `protect-main` | the default branch | pull request required (zero approvals), `CI Success` status check (strict), no deletion, no force push |
+| `protect-release-branches` | `release/*` branches | same gates as the default branch |
+| `protect-release-tags` | `v*` tags | no deletion, no force move (creation stays open) |
+
+The reasoning per branch class:
+
+- **`main`** requires a pull request and the aggregate `CI Success` check.
+  Zero required approvals is deliberate: a solo-maintainer account has no
+  second reviewer, and requiring one would deadlock the Renovate
+  patch/minor auto-merge. The pull request requirement still routes every
+  change through CI and the review tooling; the check requirement is what
+  holds an auto-merge until CI is green.
+- **`release/*`** stabilisation branches carry a shipped release for their
+  lifetime, so backports get the same gate class as `main`: pull request
+  plus `CI Success`, with the CI structural gate measuring the diff against
+  the release branch itself rather than `main`. The generated `ci.yml` runs
+  on pull requests targeting `release/*` for exactly this reason. Status
+  checks are not enforced on branch creation, so cutting `release/X.Y` is a
+  plain push.
+- **`v*` tags** are the identity of every shipped release: package
+  registries, Docker tags, and install instructions all point at them.
+  The ruleset blocks deleting or force-moving them. Creating tags stays
+  unrestricted because the release workflow creates one per release.
+
+## Who bypasses, and how
+
+Ruleset bypass lists name roles, teams, apps, or deploy keys, not user
+accounts. The shipped entry grants bypass to the **repository admin role**
+(`actor_id` 5, the one actor a template can name without knowing your
+account), with `bypass_mode: always`.
+
+The release flow depends on this. `RELEASE_TOKEN` is a personal access
+token, and a personal access token (classic or fine-grained) acts as its
+owner and holds the repository role of that owner. With the token owned by
+a repository admin, all of the release pipeline's direct pushes bypass the
+rules:
+
+- the release commit and `vX.Y.Z` tag that python-semantic-release pushes
+  to the released branch (`main` or `release/X.Y`),
+- the merge-back merge commit pushed to `main` after a release cut from a
+  `release/*` branch,
+- the owner's own hotfix pushes, preserving the escape hatch the previous
+  classic protection provided via its disabled admin enforcement.
+
+Two clean-up operations the release model implies depend on this bypass
+too. `protect-release-branches` blocks deleting a `release/X.Y` branch, and
+`protect-release-tags` blocks deleting a `v*` tag, yet a stabilisation
+branch is short-lived, and the `Pre-release check` workflow describes its
+`v<version>-rc` pre-release as safe to delete. Both deletions are available
+only to the admin role, through the same bypass. A `RELEASE_TOKEN` that is
+not owned by a repository admin cannot perform them, and those spent
+branches and pre-release tags then accumulate until an admin removes them.
+
+Everyone below admin, including outside collaborators, write-role
+contributors, and any workflow using the default `GITHUB_TOKEN`, goes
+through a pull request with green CI.
+
+If your release credential is a GitHub App installation token rather than
+a personal access token, the role-based entry does not cover it: add a
+bypass actor with `actor_type: Integration` and the app id to each
+ruleset file.
+
+## The files own the state
+
+`bootstrap.yml` upserts each ruleset by name: it updates the existing
+ruleset when one matches and creates it otherwise, replacing the whole
+ruleset with the checked-in state every time. Edits made by hand in the
+GitHub UI are reset on the next run, so change the JSON files instead. A
+push that touches `.github/rulesets/` or the bootstrap workflow re-applies
+automatically; `workflow_dispatch` re-applies on demand. Rulesets with
+other names are never touched, so you can add your own alongside.
+
+The apply step needs `administration: write`, a permission the default
+`GITHUB_TOKEN` cannot be granted, so it runs with `RELEASE_TOKEN`,
+matching the permission set the README already asks for.
+
+## Applying by hand
+
+Without the bootstrap workflow (or when importing into another repository):
+
+```bash
+gh api -X POST "repos/OWNER/REPO/rulesets" \
+  --input .github/rulesets/protect-main.json
+```
+
+or import each file in the UI under **Settings → Rules → Rulesets →
+New ruleset → Import a ruleset**. The JSON files use the same schema the
+UI exports.
+
+## Plan limits
+
+GitHub enforces rulesets on public repositories on every plan; private
+repositories need a paid plan. On a Free-plan private repository the
+ruleset API rejects the apply and the `settings` job fails; the labels
+job still runs, and the rulesets take effect once the repository is public
+or the plan allows enforcement.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,8 @@ pip install pvliesdonk-paperless-mcp
 docker pull ghcr.io/pvliesdonk/paperless-mcp:latest
 ```
 
+The `latest` tag is the newest stable release. The rolling `edge` tag tracks every merge to `main` and carries no version identity; see [Image tags](deployment/docker.md#image-tags) for the full list.
+
 ## From source
 
 ```bash

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,13 @@
+# Release Notes
+
+Each minor release series gets one page here telling its story: what
+changed, why it matters, and how to adopt it. Patch releases add a dated
+section to their series page, so a series stays one linkable document.
+The commit-level record lives in the repository's `CHANGELOG.md`; each
+GitHub release links back to its page here.
+
+<!-- RELEASE-PAGES-START: newest series first; one list entry per page.
+     The first real entry replaces the placeholder line below. -->
+No release pages yet. The first entry appears with the first stable
+release cut after this project adopted release-notes pages.
+<!-- RELEASE-PAGES-END -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,10 @@ plugins:
           - prompts.md
         Deployment:
           - deployment/*.md
+        # Glob deliberately: each minor's release-notes page is auto-indexed
+        # without a sections-list update (same rationale as guides/*).
+        Release Notes:
+          - releases/*.md
         # PROJECT-LLMSTXT-SECTIONS-END
   - mkdocstrings:
       handlers:
@@ -129,4 +133,10 @@ nav:
       - Docker: deployment/docker.md
       - OIDC Authentication: deployment/oidc.md
       - Claude Desktop: deployment/claude-desktop.md
+      - Release Process: deployment/release-process.md
+      - Repository Protection: deployment/repository-protection.md
+  # Landing page only, deliberately: per-minor pages stay out of nav so a new
+  # release never needs a nav edit (mkdocs treats not-in-nav pages as INFO,
+  # so `--strict` stays green); the landing page and search link them.
+  - Release Notes: releases/index.md
   # PROJECT-NAV-END

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,15 +264,74 @@ assets = [
     "uv.lock",
 
     # The Claude Code plugin channel's manifests, bumped by
-    # scripts/bump_manifests.py in the same release commit.
+    # scripts/bump_manifests.py in the same release commit (stable releases
+    # only — pre-releases leave them at the last published stable, since the
+    # PyPI version they pin is never published for a pre-release).
     ".claude-plugin/plugin/.claude-plugin/plugin.json",
     ".claude-plugin/plugin/.mcp.json",
 
 ]
 
+# Branch groups: prerelease-ness is a property of the BRANCH, not of a
+# dispatch flag.  `main` always releases stable; a short-lived `release/X.Y`
+# stabilisation branch releases rcs by default, with the release workflow's
+# `finalize` input cutting the final stable X.Y.Z from the branch (it
+# generates a one-run config override, since PSR's CLI can force prerelease
+# ON but not OFF).  A branch matching neither pattern cannot release at all —
+# PSR refuses, which is the desired guard.  After ANY release cut from a
+# `release/*` branch, the branch must merge back into `main` (the release
+# workflow's merge-back job): with the tag unreachable from `main`, PSR
+# computes the same version from `main`'s own history, finds the tag taken
+# repo-globally, and reports "already released" forever.
+[tool.semantic_release.branches.main]
+match = "(main|master)"
+prerelease = false
+
+[tool.semantic_release.branches.release]
+match = "release/.*"
+prerelease = true
+prerelease_token = "rc"
+
+# PSR's changelog runs in `update` mode (the v10 default, pinned here so the
+# contract is visible): each release inserts its version section at the
+# insertion flag in CHANGELOG.md and preserves everything else in the file
+# verbatim.  Both halves are explicit because the flag is load-bearing — a
+# changelog without the flag line is silently never written (template#350).
+# CHANGELOG.md is seeded with the flag; a project whose CHANGELOG.md predates
+# it must add the flag line once, by hand (tests/test_release_contract.py
+# fails with the exact line until it is present).
 [tool.semantic_release.changelog]
+mode = "update"
+insertion_flag = "<!-- version list -->"
+
+# `changelog_file` lives under `default_templates` (its supported location
+# since PSR v9.11); the bare `changelog.changelog_file` key is deprecated.
+[tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.commit_parser_options]
+# The accepted commit types, stated explicitly rather than left to the
+# parser's default, because this list is one half of a contract: CI's
+# `PR Title` job runs scripts/check_pr_title.py against the same set, and
+# tests/test_commit_conventions.py fails when the two halves disagree.
+#
+# Getting a type wrong is not a cosmetic problem. A subject whose type is not
+# listed here does not parse, and PSR then omits the commit from CHANGELOG.md
+# entirely — no fallback heading, no warning. `revert` is added on top of the
+# parser's own default set for exactly that reason: reverts belong in the
+# audit trail, and the default drops them.
+allowed_tags = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard"],
   "labels": ["dependencies"],
   "enabledManagers": ["pep621"],
+  "semanticCommits": "enabled",
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {
     "enabled": true,

--- a/scripts/bump_manifests.py
+++ b/scripts/bump_manifests.py
@@ -10,6 +10,16 @@ release commit — which is the commit it then tags.
 The script runs inside PSR's Docker action container (python:3.14-slim), which
 has Python but no ``jq`` — hence Python rather than a shell+jq wrapper.
 
+Pre-releases are handled differently (#345): the release workflow's
+``publish-pypi`` and ``publish-registry`` jobs (and the marketplace publish)
+all skip pre-releases, so a pre-release version never exists on PyPI or the
+MCP registry.  Manifests whose version fields name a *published* artifact —
+``server.json`` and the Claude Code plugin pair — are therefore left at the
+last published stable on pre-release runs, and the next stable release
+re-bumps them.  Only ``uv.lock`` is refreshed unconditionally: it tracks
+``pyproject.toml``, not PyPI, and letting it lag would break ``uv lock
+--check`` on the release commit.
+
 This file is TEMPLATE-OWNED: it re-renders on every ``copier update``, so a
 fix to the shared bumpers (``server.json``, ``uv.lock``) arrives whole rather
 than half — the ``assets`` half landing in the re-rendered ``pyproject.toml``
@@ -47,93 +57,30 @@ def _dump(path: Path, data: Any) -> None:
         fh.write("\n")
 
 
-def _bump_lockfile(version: str) -> None:
-    """Refresh ``uv.lock``'s self-referential ``[[package]]`` version.
+def _is_prerelease(version: str) -> bool:
+    """Return True unless ``version`` is a plain stable ``X.Y.Z``.
 
-    PSR bumps ``pyproject.toml:project.version`` but nothing re-locks, so
-    without this the release commit ships a lockfile whose self entry still
-    carries the previous version.  That drift then self-heals as a side
-    effect of the next ``uv run`` rewriting ``uv.lock`` — tripping
-    pre-commit's "files were modified by this hook" guard on an unrelated
-    later commit.  PSR's container has no ``uv``, so rewrite the one
-    version line textually instead of running ``uv lock``.
+    PSR (``tag_format = "v{version}"``, ``prerelease_token: rc``) emits
+    stable versions as ``X.Y.Z`` and pre-releases in SemVer form as
+    ``X.Y.Z-rc.N``.  The check is deliberately conservative: anything that
+    is not a plain three-component release (a pre-release, a build tag, an
+    unexpected format) keeps the PyPI-referencing pins at the last published
+    stable instead of pinning a version that may never exist on PyPI.
+    Stdlib-only on purpose — PSR's container Python has no guaranteed
+    ``packaging`` install.
     """
-    lock_path = Path("uv.lock")
-    if not lock_path.exists():
-        # A fresh scaffold has no lockfile until the first `uv sync`.
-        print("bump_manifests: uv.lock not found — skipped", file=sys.stderr)
-        return
-    with Path("pyproject.toml").open("rb") as fh:
-        name = tomllib.load(fh)["project"]["name"]
-    # uv writes the PEP 503-normalized name into the lockfile.
-    normalized = re.sub(r"[-_.]+", "-", name).lower()
-    text = lock_path.read_text(encoding="utf-8")
-    pattern = (
-        r'(\[\[package\]\]\nname = "'
-        + re.escape(normalized)
-        + r'"\nversion = ")[^"]*(")'
-    )
-    new_text, n = re.subn(
-        pattern, lambda m: m.group(1) + version + m.group(2), text, count=1
-    )
-    if n == 0:
-        print(
-            f"WARNING: uv.lock has no [[package]] entry named {normalized!r} "
-            "— left unchanged",
-            file=sys.stderr,
-        )
-        return
-    lock_path.write_text(new_text, encoding="utf-8")
-    print(f"bump_manifests: uv.lock ({normalized}) → {version}")
+    return re.fullmatch(r"\d+\.\d+\.\d+", version) is None
 
 
-def _bump_claude_plugin_manifests(version: str) -> None:
-    """Bump the Claude Code plugin channel's two version-coupled manifests.
+def _bump_server_json(version: str) -> int:
+    """Bump ``server.json``: top-level version, PyPI package version, OCI tag.
 
-    ``plugin.json``'s ``version`` and ``.mcp.json``'s ``--from`` pin move in
-    lockstep with the release, so the marketplace entry the release workflow
-    publishes always installs the version it points at. Only the version
-    part after ``==`` is rewritten; the package spec (name and extras) stays
-    whatever the project configured.
+    Called for stable releases only — both version fields name artifacts that
+    are published exclusively for stable releases, so pre-release runs leave
+    the file at the last published stable (see ``main()``).  Replace only the
+    ``:v<old>`` suffix of the OCI identifier so forks/renames keep their own
+    ``ghcr.io/<owner>/<image>`` base.  Returns a process exit code.
     """
-    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
-    manifest = _load(plugin_path)
-    manifest["version"] = version
-    _dump(plugin_path, manifest)
-
-    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
-    mcp = _load(mcp_path)
-    for server in mcp.values():
-        args = server.get("args", [])
-        for i, arg in enumerate(args):
-            if arg == "--from" and i + 1 < len(args):
-                spec = args[i + 1].split("==", 1)[0]
-                args[i + 1] = f"{spec}=={version}"
-    _dump(mcp_path, mcp)
-
-
-# DOMAIN-MANIFESTS-HELPERS-START — module-level helpers for this project's own
-# versioned manifests (a `_bump_plugin_json(version)`, a TOML rewriter, ...).
-# `_load` / `_dump` above read and write JSON in the byte format the rest of
-# the toolchain expects (indent=2, ensure_ascii=False, trailing newline) —
-# scripts/gen_config_surface.py asserts that format, so prefer them over a
-# bare `json.dump`.  Call what you define from the DOMAIN-MANIFESTS block in
-# `main()` below.  Kept across copier update.
-# DOMAIN-MANIFESTS-HELPERS-END
-
-
-def main() -> int:
-    version = os.environ.get("NEW_VERSION")
-    if not version:
-        print(
-            "NEW_VERSION must be set (python-semantic-release build_command env)",
-            file=sys.stderr,
-        )
-        return 1
-
-    # server.json: top-level version, PyPI package version, OCI tag suffix.
-    # Replace only the ``:v<old>`` suffix of the OCI identifier so forks/renames
-    # keep their own ``ghcr.io/<owner>/<image>`` base.
     server_path = Path("server.json")
     if not server_path.exists():
         print(
@@ -182,13 +129,120 @@ def main() -> int:
                 )
             pkg["identifier"] = new_id
     _dump(server_path, server)
-
     print(f"bump_manifests: server.json → {version}")
+    return 0
+
+
+def _bump_lockfile(version: str) -> None:
+    """Refresh ``uv.lock``'s self-referential ``[[package]]`` version.
+
+    PSR bumps ``pyproject.toml:project.version`` but nothing re-locks, so
+    without this the release commit ships a lockfile whose self entry still
+    carries the previous version.  That drift then self-heals as a side
+    effect of the next ``uv run`` rewriting ``uv.lock`` — tripping
+    pre-commit's "files were modified by this hook" guard on an unrelated
+    later commit.  PSR's container has no ``uv``, so rewrite the one
+    version line textually instead of running ``uv lock``.
+    """
+    lock_path = Path("uv.lock")
+    if not lock_path.exists():
+        # A fresh scaffold has no lockfile until the first `uv sync`.
+        print("bump_manifests: uv.lock not found — skipped", file=sys.stderr)
+        return
+    with Path("pyproject.toml").open("rb") as fh:
+        name = tomllib.load(fh)["project"]["name"]
+    # uv writes the PEP 503-normalized name into the lockfile.
+    normalized = re.sub(r"[-_.]+", "-", name).lower()
+    text = lock_path.read_text(encoding="utf-8")
+    pattern = (
+        r'(\[\[package\]\]\nname = "'
+        + re.escape(normalized)
+        + r'"\nversion = ")[^"]*(")'
+    )
+    new_text, n = re.subn(
+        pattern, lambda m: m.group(1) + version + m.group(2), text, count=1
+    )
+    if n == 0:
+        print(
+            f"WARNING: uv.lock has no [[package]] entry named {normalized!r} "
+            "— left unchanged",
+            file=sys.stderr,
+        )
+        return
+    lock_path.write_text(new_text, encoding="utf-8")
+    print(f"bump_manifests: uv.lock ({normalized}) → {version}")
+
+
+def _bump_claude_plugin_manifests(version: str) -> None:
+    """Bump the Claude Code plugin channel's two version-coupled manifests.
+
+    ``plugin.json``'s ``version`` and ``.mcp.json``'s ``--from`` pin move in
+    lockstep, so the marketplace entry the release workflow publishes always
+    installs the version it points at.  Called for stable releases only: the
+    pin references PyPI and pre-releases are never published there, so on
+    pre-release runs both files stay at the last published stable (see
+    ``main()``).  Only the version part after ``==`` is rewritten; the
+    package spec (name and extras) stays whatever the project configured.
+    """
+    plugin_path = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
+    manifest = _load(plugin_path)
+    manifest["version"] = version
+    _dump(plugin_path, manifest)
+
+    mcp_path = Path(".claude-plugin/plugin/.mcp.json")
+    mcp = _load(mcp_path)
+    for server in mcp.values():
+        args = server.get("args", [])
+        for i, arg in enumerate(args):
+            if arg == "--from" and i + 1 < len(args):
+                spec = args[i + 1].split("==", 1)[0]
+                args[i + 1] = f"{spec}=={version}"
+    _dump(mcp_path, mcp)
+
+
+# DOMAIN-MANIFESTS-HELPERS-START — module-level helpers for this project's own
+# versioned manifests (a `_bump_plugin_json(version)`, a TOML rewriter, ...).
+# `_load` / `_dump` above read and write JSON in the byte format the rest of
+# the toolchain expects (indent=2, ensure_ascii=False, trailing newline) —
+# scripts/gen_config_surface.py asserts that format, so prefer them over a
+# bare `json.dump`.  Call what you define from the DOMAIN-MANIFESTS block in
+# `main()` below.  Kept across copier update.
+# DOMAIN-MANIFESTS-HELPERS-END
+
+
+def main() -> int:
+    version = os.environ.get("NEW_VERSION")
+    if not version:
+        print(
+            "NEW_VERSION must be set (python-semantic-release build_command env)",
+            file=sys.stderr,
+        )
+        return 1
+
+    prerelease = _is_prerelease(version)
+    if prerelease:
+        # Pre-releases skip publish-pypi / publish-registry / the marketplace
+        # publish, so rewriting the manifests that name a published artifact
+        # would pin a version that never exists there (#345).  Leave them at
+        # the last published stable; the next stable release re-bumps them.
+        print(
+            f"bump_manifests: {version} is a pre-release — "
+            "server.json and the Claude plugin "
+            "manifests left at the last published stable"
+        )
+    else:
+        rc = _bump_server_json(version)
+        if rc != 0:
+            return rc
     _bump_lockfile(version)
-    _bump_claude_plugin_manifests(version)
+    if not prerelease:
+        _bump_claude_plugin_manifests(version)
     # DOMAIN-MANIFESTS-START — bump this project's extra versioned manifests
-    # here; `version` is the new version string, and the repo root is the cwd.
-    # Every path touched here must also be listed in `pyproject.toml`
+    # here; `version` is the new version string, `prerelease` says whether it
+    # is a pre-release, and the repo root is the cwd.  A manifest that names a
+    # published artifact (a PyPI pin, a registry entry) should follow the same
+    # rule as the template's own bumps: skip the rewrite when `prerelease` is
+    # true.  Every path touched here must also be listed in `pyproject.toml`
     # `[tool.semantic_release] assets`, or PSR leaves it out of the release
     # commit.  Kept across copier update; everything outside these markers is
     # template-owned and re-rendered, which is what keeps the bumpers above in

--- a/scripts/check_pr_title.py
+++ b/scripts/check_pr_title.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Check a pull-request title against the conventional-commit type set.
+
+A squash merge takes the pull-request title as the resulting commit subject,
+so the title is the last point at which a subject can be corrected before it
+reaches ``main``.  That matters more than style: python-semantic-release
+builds its subject regex from the types listed in ``pyproject.toml``'s
+``[tool.semantic_release.commit_parser_options] allowed_tags``, and a subject
+whose type is not among them fails to parse and is dropped from the generated
+``CHANGELOG.md`` entirely -- not filed under a fallback heading, absent.  The
+release audit trail is only as complete as the subjects feeding it.
+
+The type list below and ``allowed_tags`` are two halves of one contract.
+``tests/test_commit_conventions.py`` fails when they disagree, so neither half
+can drift alone.
+
+Usage::
+
+    python3 scripts/check_pr_title.py "feat(search): add hybrid ranking"
+    python3 scripts/check_pr_title.py --list
+
+Exits 0 when the title conforms, 1 otherwise, after printing a GitHub
+workflow error annotation naming the accepted types.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+#: Commit types this project accepts, kept in agreement with
+#: ``[tool.semantic_release.commit_parser_options] allowed_tags``.
+ALLOWED_TYPES: tuple[str, ...] = (
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+)
+
+# Mirrors python-semantic-release's angular parser: an optional
+# parenthesised scope, an optional `!` breaking marker, a colon, whitespace,
+# then a non-empty subject.  Case-sensitive, as the parser is.
+_TITLE_RE = re.compile(
+    r"^(?P<type>[A-Za-z]+)"
+    r"(?:\((?P<scope>[^()\n]+)\))?"
+    r"(?P<breaking>!)?"
+    r":[ \t]+"
+    r"(?P<subject>\S.*)$"
+)
+
+# `git revert` and GitHub's revert button both produce `Revert "<original>"`.
+# That is the wider ecosystem's shape, not a GitHub quirk, and Conventional
+# Commits deliberately leaves revert handling open -- so it is accepted rather
+# than second-guessed.  The greedy `.+` also accepts the stacked form a revert
+# of a revert produces: `Revert "Revert "feat: x""`.
+#
+# It does carry a cost, and the caller is told about it rather than left to
+# find out: python-semantic-release has no revert handling in any parser (both
+# `angular` and `conventional` return ParseError for this shape), so a commit
+# with this subject does not reach CHANGELOG.md.  The release-notes page is
+# where such a change gets narrated -- its research runs off merged pull
+# requests and linked issues, not commit subjects.
+_GIT_REVERT_RE = re.compile(r'^Revert\s+".+"\s*$')
+
+_TYPES_LINE = ", ".join(ALLOWED_TYPES)
+
+_HOW_TO_FIX = (
+    "Retitle the pull request, then re-run this job -- it reads the current "
+    "title from the API, so no push is needed."
+)
+
+
+def _example() -> str:
+    return (
+        "Accepted shape: type(optional-scope)!: subject\n"
+        "  feat(search): add hybrid ranking\n"
+        "  fix: stop the writer thread on shutdown\n"
+        "  feat(config)!: drop the deprecated env alias\n"
+        f"Accepted types: {_TYPES_LINE}"
+    )
+
+
+#: Emitted for an accepted title that the release parser still cannot read.
+REVERT_CAVEAT = (
+    'Accepted: this is the Revert "..." form git and GitHub generate. '
+    "python-semantic-release cannot parse it, though, so the commit will not "
+    "appear in CHANGELOG.md. Title it 'revert: ORIGINAL SUBJECT' instead if "
+    "you want it there; either way the release-notes page narrates it, since "
+    "that research runs off merged pull requests rather than commit subjects."
+)
+
+
+def is_git_revert(title: str) -> bool:
+    """Report whether a title is the ``Revert "..."`` form git generates.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``True`` for the git/GitHub revert shape, including the stacked form
+        a revert of a revert produces (``Revert`` applied twice).
+    """
+    return _GIT_REVERT_RE.match(title.strip()) is not None
+
+
+def check_title(title: str) -> str | None:
+    """Validate a pull-request title.
+
+    Args:
+        title: The pull-request title, as GitHub reports it.
+
+    Returns:
+        ``None`` when the title conforms, otherwise a multi-line explanation
+        of what is wrong and how to fix it.
+    """
+    stripped = title.strip()
+    if not stripped:
+        return f"The pull-request title is empty.\n{_example()}\n{_HOW_TO_FIX}"
+
+    if is_git_revert(stripped):
+        return None
+
+    match = _TITLE_RE.match(stripped)
+    if not match:
+        return (
+            "The pull-request title is not a conventional-commit subject.\n"
+            f"{_example()}\n{_HOW_TO_FIX}"
+        )
+
+    commit_type = match.group("type")
+    if commit_type not in ALLOWED_TYPES:
+        lowered = commit_type.lower()
+        hint = ""
+        if lowered in ALLOWED_TYPES:
+            hint = f"\nTypes are case-sensitive; use {lowered!r}, not {commit_type!r}."
+        return (
+            f"{commit_type!r} is not an accepted commit type. A subject with "
+            "an unrecognised type is dropped from CHANGELOG.md without a "
+            "warning.\n"
+            f"Accepted types: {_TYPES_LINE}{hint}\n{_HOW_TO_FIX}"
+        )
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    """Run the check.
+
+    Args:
+        argv: Command-line arguments without the program name. Either
+            ``["--list"]`` or a single pull-request title.
+
+    Returns:
+        Process exit status: 0 when the title conforms, 1 otherwise.
+    """
+    if argv == ["--list"]:
+        print("\n".join(ALLOWED_TYPES))
+        return 0
+    if len(argv) != 1:
+        print("usage: check_pr_title.py [--list | TITLE]", file=sys.stderr)
+        return 2
+
+    problem = check_title(argv[0])
+    if problem is None:
+        print(f"Pull-request title OK: {argv[0]}")
+        if is_git_revert(argv[0]):
+            print(REVERT_CAVEAT)
+            print(f"::warning title=Revert title::{REVERT_CAVEAT}")
+        return 0
+
+    print(problem, file=sys.stderr)
+    summary = problem.splitlines()[0]
+    print(f"::error title=Pull-request title::{summary}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/merge_back.sh
+++ b/scripts/merge_back.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Merge a release branch back into the currently checked-out branch (normally
+# the default branch) after a release was cut from it.
+#
+# Why this exists: after any release cut from a release/X.Y branch, the new
+# tag is unreachable from main until the branch merges back.  PSR's
+# already-released check is repo-global while its version computation is
+# ancestry-scoped, so an unmerged branch release deadlocks main — PSR
+# recomputes the same version from main's own history, finds the tag taken,
+# and reports "already released" forever.  The release workflow's merge-back
+# job runs this script; it is also safe to run by hand from a main checkout.
+#
+# Conflict policy: version-coupled files (pyproject.toml, the changelog, and
+# every [tool.semantic_release] asset) resolve to the CURRENT branch's side —
+# main is authoritative for current version metadata, and the release tag
+# preserves the branch's own state.  Any other conflict means real divergence
+# a human must look at: the merge is aborted, the tree left clean, and the
+# script exits non-zero.
+#
+# Usage: merge_back.sh <release-ref> <tag>
+#   release-ref  the branch to merge back, e.g. origin/release/4.0
+#   tag          the tag just released from it (commit-message context only)
+#
+# Requires python3 >= 3.11 (tomllib) to read the asset list from
+# pyproject.toml, so the file list can never drift from what PSR stages.
+set -euo pipefail
+
+release_ref="${1:?usage: merge_back.sh <release-ref> <tag>}"
+tag="${2:?usage: merge_back.sh <release-ref> <tag>}"
+
+if git merge-base --is-ancestor "$release_ref" HEAD; then
+    echo "merge_back: ${release_ref} is already reachable from HEAD; nothing to do"
+    exit 0
+fi
+
+coupled="$(python3 - <<'PY'
+import tomllib
+
+with open("pyproject.toml", "rb") as fh:
+    cfg = tomllib.load(fh)["tool"]["semantic_release"]
+files = {"pyproject.toml"}
+changelog_cfg = cfg.get("changelog", {})
+files.add(
+    changelog_cfg.get("default_templates", {}).get("changelog_file")
+    or changelog_cfg.get("changelog_file")  # pre-v9.11 deprecated location
+    or "CHANGELOG.md"
+)
+files.update(str(asset) for asset in cfg.get("assets", []))
+print("\n".join(sorted(files)))
+PY
+)"
+
+if ! git merge --no-ff --no-commit "$release_ref"; then
+    while IFS= read -r f; do
+        if git ls-files --unmerged -- "$f" | grep -q .; then
+            if git checkout --ours -- "$f" 2>/dev/null; then
+                git add -- "$f"
+            fi
+        fi
+    done <<<"$coupled"
+    remaining="$(git diff --name-only --diff-filter=U)"
+    if [ -n "$remaining" ]; then
+        echo "merge_back: conflicts outside the version-coupled files need a human:" >&2
+        printf '%s\n' "$remaining" >&2
+        git merge --abort
+        exit 1
+    fi
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+git commit -m "chore(release): merge ${release_ref#origin/} back into ${current_branch} after ${tag}"

--- a/scripts/structural_gate.sh
+++ b/scripts/structural_gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Structural diff gate — the ONE implementation shared by the pre-push hook
+# (.pre-commit-config.yaml) and ci.yml's `structure` job, so the command and
+# its ruff selection cannot drift between the two.
+#
+# Compare-branch resolution, in order:
+#   1. STRUCTURAL_GATE_BASE — explicit override; CI sets it to the PR's
+#      actual base (origin/<base_ref>).
+#   2. Derived: the nearest base among origin/main and origin/release/*,
+#      picked by most-recent merge-base with HEAD.  A feature branch off main
+#      resolves to origin/main; a backport branch off release/X.Y resolves to
+#      origin/release/X.Y, so backport PRs are measured against the branch
+#      they actually target instead of an ever-growing diff vs main.
+#   3. origin/main, when nothing else resolves (fresh clone, no remotes).
+set -euo pipefail
+
+base="${STRUCTURAL_GATE_BASE:-}"
+if [ -z "$base" ]; then
+    best_ts=0
+    for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/main 'refs/remotes/origin/release/*'); do
+        mb="$(git merge-base HEAD "$ref" 2>/dev/null)" || continue
+        ts="$(git log -1 --format=%ct "$mb")"
+        # Strict > prefers the earlier-listed origin/main on a timestamp tie.
+        if [ "$ts" -gt "$best_ts" ]; then
+            best_ts="$ts"
+            base="$ref"
+        fi
+    done
+fi
+base="${base:-origin/main}"
+
+# Test seam: print the resolved base and exit, so the derivation is testable
+# without diff-quality or a venv (see tests/test_structural_gate.py).
+if [ -n "${STRUCTURAL_GATE_PRINT_BASE:-}" ]; then
+    printf '%s\n' "$base"
+    exit 0
+fi
+
+# No Python in the diff → nothing for the gate to measure (mirrors the
+# diff-cover guard; the pre-push hook also skips via `types: [python]`).
+has_py="$(git diff --name-only "${base}...HEAD" | grep -c '\.py$' || true)"
+if [ "$has_py" -eq 0 ]; then
+    echo "No Python source changes — skipping structural diff gate"
+    exit 0
+fi
+
+echo "structural gate: comparing against ${base}"
+uv run diff-quality --violations=ruff.check \
+    --options="--extend-select=C901,PLR0911,PLR0912,PLR0913,PLR0915,S" \
+    --compare-branch="${base}" --fail-under=100

--- a/tests/public_import_surface.txt
+++ b/tests/public_import_surface.txt
@@ -1,0 +1,12 @@
+# Public import surface of the `paperless_mcp` package root — one name
+# per line, sorted.  `#` lines and blank lines are ignored.
+#
+# Project-owned (seeded once by the template, never re-rendered), consumed by
+# the template-owned tests/test_import_surface.py.  Regenerate with:
+#
+#     uv run python tests/test_import_surface.py --update
+#
+# Removing a name from this file is a breaking change to the public library
+# interface: the commit that does it must be marked breaking (`feat!:` /
+# `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy
+# (pvliesdonk/fastmcp-server-template#342).

--- a/tests/test_commit_conventions.py
+++ b/tests/test_commit_conventions.py
@@ -1,0 +1,146 @@
+"""Guards for the commit-type contract between PSR, CI, and the docs.
+
+Three places name the accepted commit types: `pyproject.toml`'s
+`[tool.semantic_release.commit_parser_options] allowed_tags` (what
+python-semantic-release will parse), `scripts/check_pr_title.py` (what CI
+rejects before a squash merge turns a title into a subject), and `CLAUDE.md`
+(what a contributor reads). Let any one drift and the failure is silent: PSR
+does not warn about a subject it cannot parse, it simply omits the commit from
+`CHANGELOG.md` — no fallback heading, no entry.
+
+That is not hypothetical. Seven commits reached one downstream project's
+`main` with `diag(review):` / `experiment(review):` / prose subjects and are
+absent from its generated changelog (see the template's #368). These tests are
+what keeps the three halves honest.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts" / "check_pr_title.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+
+def _parser_options() -> dict[str, list[str]]:
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    options = data["tool"]["semantic_release"]["commit_parser_options"]
+    return {key: [str(item) for item in value] for key, value in options.items()}
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _checker_types() -> list[str]:
+    result = _run_checker("--list")
+    assert result.returncode == 0, result.stderr
+    return result.stdout.split()
+
+
+def test_checker_and_psr_accept_the_same_types() -> None:
+    """The gate must not reject what PSR accepts, or accept what it drops."""
+    assert set(_checker_types()) == set(_parser_options()["allowed_tags"])
+
+
+def test_release_bump_types_are_parseable() -> None:
+    """A type that bumps a version but does not parse would never bump one."""
+    options = _parser_options()
+    bumping = set(options["minor_tags"]) | set(options["patch_tags"])
+    assert bumping <= set(options["allowed_tags"])
+
+
+def test_claude_md_documents_every_accepted_type() -> None:
+    """Contributors read CLAUDE.md; an undocumented type is a trap."""
+    prose = CLAUDE_MD.read_text(encoding="utf-8")
+    missing = [f"`{tag}`" for tag in _checker_types() if f"`{tag}`" not in prose]
+    assert not missing, f"CLAUDE.md does not document: {missing}"
+
+
+def test_ci_runs_the_checker_and_gates_on_it() -> None:
+    """The check is worthless unless the required aggregate depends on it."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/check_pr_title.py" in workflow
+    assert "\n      - pr-title\n" in workflow, (
+        "the pr-title job must be a `needs` entry of the ci-success aggregate"
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "feat: add a thing",
+        "fix(search): stop the writer thread on shutdown",
+        "feat(config)!: drop the deprecated env alias",
+        "chore(deps): update dependency ruff to v0.9.0",
+        "revert: feat(search): add hybrid ranking",
+        'Revert "feat: add a thing"',
+        'Revert "Revert "feat: add a thing""',
+        "perf: reuse the compiled pattern",
+        "docs: document the new env var",
+    ],
+)
+def test_accepted_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "diag(review): pin the reviewer action",
+        "experiment(review): show full output",
+        "Modify CI workflow to handle Renovate PRs",
+        'Reverted "feat: add a thing"',
+        "Feat: capitalised type",
+        "fix:no space after the colon",
+        "feat: ",
+        "",
+    ],
+)
+def test_rejected_titles(title: str) -> None:
+    result = _run_checker(title)
+    assert result.returncode == 1
+    assert "::error" in result.stdout
+
+
+def test_rejection_names_the_accepted_types() -> None:
+    """An actionable failure tells the author what to type instead."""
+    result = _run_checker("diag(review): pin the reviewer action")
+    assert result.returncode == 1
+    assert ", ".join(_checker_types()) in result.stderr
+
+
+def test_git_revert_titles_pass_but_warn_about_the_changelog() -> None:
+    """The git/GitHub revert form is accepted; its cost is stated, not hidden.
+
+    Neither of python-semantic-release 10.5.3's parsers reads that shape --
+    both return ParseError -- so the commit never reaches CHANGELOG.md. The
+    check accepts the title (it is what git itself generates) and annotates
+    the run rather than leaving the author to discover the gap at release
+    time.
+    """
+    result = _run_checker('Revert "feat: add a thing"')
+    assert result.returncode == 0, result.stderr
+    assert "::warning" in result.stdout
+    assert "CHANGELOG.md" in result.stdout
+
+
+def test_conventional_revert_titles_pass_without_a_warning() -> None:
+    """`revert:` is in allowed_tags, so that form does reach the changelog."""
+    result = _run_checker("revert: feat: add a thing")
+    assert result.returncode == 0, result.stderr
+    assert "::warning" not in result.stdout

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -16,7 +16,9 @@ invokes ``pytest ... -m browser``.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from playwright.sync_api import Browser, Page
@@ -72,3 +74,38 @@ def test_tool_visibility_emits_the_allowlist(page: Page) -> None:
     output = page.inner_text(".cfg-output")
     assert "PAPERLESS_MCP_TOOLS_ALLOW=search_documents" in output
     assert "PAPERLESS_MCP_TOOLS_DENY=" not in output
+
+
+def test_install_manifests_expose_required_paperless_configuration() -> None:
+    """Generated MCPB and plugin screens expose the required Paperless settings."""
+    repo_root = Path(__file__).resolve().parents[1]
+    mcpb = json.loads(
+        (repo_root / "packaging/mcpb/manifest.json.in").read_text(encoding="utf-8")
+    )
+    plugin = json.loads(
+        (repo_root / ".claude-plugin/plugin/.claude-plugin/plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    plugin_mcp = json.loads(
+        (repo_root / ".claude-plugin/plugin/.mcp.json").read_text(encoding="utf-8")
+    )
+
+    for manifest in (mcpb, plugin):
+        user_config = manifest.get("user_config", manifest.get("userConfig"))
+        assert user_config["paperless_url"]["required"] is True
+        assert user_config["api_token"]["required"] is True
+        assert user_config["api_token"]["sensitive"] is True
+
+    api_token_reference = "${user_config.api_token}"
+    assert (
+        mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_PAPERLESS_URL"]
+        == "${user_config.paperless_url}"
+    )
+    assert (
+        mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_API_TOKEN"]
+        == api_token_reference
+    )
+    env = plugin_mcp["paperless-mcp"]["env"]
+    assert env["PAPERLESS_MCP_PAPERLESS_URL"] == "${user_config.paperless_url}"
+    assert env["PAPERLESS_MCP_API_TOKEN"] == api_token_reference

--- a/tests/test_config_wizard_domain.py
+++ b/tests/test_config_wizard_domain.py
@@ -97,15 +97,15 @@ def test_install_manifests_expose_required_paperless_configuration() -> None:
         assert user_config["api_token"]["required"] is True
         assert user_config["api_token"]["sensitive"] is True
 
-    api_token_reference = "${user_config.api_token}"
+    config_reference = "${user_config.api_token}"
     assert (
         mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_PAPERLESS_URL"]
         == "${user_config.paperless_url}"
     )
     assert (
         mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_API_TOKEN"]
-        == api_token_reference
+        == config_reference
     )
     env = plugin_mcp["paperless-mcp"]["env"]
     assert env["PAPERLESS_MCP_PAPERLESS_URL"] == "${user_config.paperless_url}"
-    assert env["PAPERLESS_MCP_API_TOKEN"] == api_token_reference
+    assert env["PAPERLESS_MCP_API_TOKEN"] == config_reference

--- a/tests/test_import_surface.py
+++ b/tests/test_import_surface.py
@@ -1,0 +1,183 @@
+"""Guard for the public import surface of the `paperless_mcp` package root.
+
+A change that removes or renames a name importable from the package root is a
+breaking change to the public library interface, and must be marked as such
+(`feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer) so the release pipeline
+cuts a major.  Historically this class of break shipped unmarked: the author
+sees an internal refactor, downstream consumers see `ImportError`.  These tests
+make the surface mechanical — the project-owned snapshot
+`tests/public_import_surface.txt` is the expected set of names, and any drift
+between it and the real, imported package fails at PR time with instructions.
+
+The surface definition: every non-underscore name in ``dir(package)`` or
+``__all__`` that resolves via ``getattr``, enumerated in a fresh interpreter.
+``dir()`` + ``getattr`` (rather than a static ``__all__`` read) is deliberate —
+a root that re-exports through a lazy PEP 562 ``__getattr__`` map still counts,
+and a minimal root exporting nothing yields an empty surface.  The fresh
+interpreter keeps the result independent of whatever submodules earlier tests
+happened to import.
+
+Ownership: this file is template-owned (re-rendered on `copier update`); the
+snapshot is project-owned (seeded once, then yours).  Regenerate it with::
+
+    uv run python tests/test_import_surface.py --update
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SNAPSHOT = REPO_ROOT / "tests" / "public_import_surface.txt"
+UPDATE_COMMAND = "uv run python tests/test_import_surface.py --update"
+
+_HEADER = """\
+# Public import surface of the `paperless_mcp` package root — one name
+# per line, sorted.  `#` lines and blank lines are ignored.
+#
+# Project-owned (seeded once by the template, never re-rendered), consumed by
+# the template-owned tests/test_import_surface.py.  Regenerate with:
+#
+#     uv run python tests/test_import_surface.py --update
+#
+# Removing a name from this file is a breaking change to the public library
+# interface: the commit that does it must be marked breaking (`feat!:` /
+# `fix!:`, or a `BREAKING CHANGE:` footer) per the versioning policy
+# (pvliesdonk/fastmcp-server-template#342).
+"""
+
+# Runs in a fresh interpreter so the enumeration cannot be polluted by
+# submodules that earlier tests imported (importing `pkg.sub` binds `sub` as an
+# attribute of `pkg` for the rest of the process).
+_ENUMERATE = """\
+import importlib
+import json
+
+module = importlib.import_module("paperless_mcp")
+names = set(dir(module)) | set(getattr(module, "__all__", ()))
+missing = object()
+public = sorted(
+    name
+    for name in names
+    if not name.startswith("_") and getattr(module, name, missing) is not missing
+)
+print(json.dumps(public))
+"""
+
+
+def current_surface() -> list[str]:
+    """Enumerate the package root's public names in a fresh interpreter.
+
+    Returns:
+        Sorted list of public attribute names importable from the package root.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-P", "-c", _ENUMERATE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result: list[str] = json.loads(proc.stdout)
+    return result
+
+
+def snapshot_names() -> list[str]:
+    """Parse the snapshot file: one name per line, `#` comments and blanks ignored.
+
+    Returns:
+        The declared names, in file order.
+    """
+    lines = SNAPSHOT.read_text(encoding="utf-8").splitlines()
+    stripped = (line.strip() for line in lines)
+    return [line for line in stripped if line and not line.startswith("#")]
+
+
+def test_snapshot_file_exists() -> None:
+    """The snapshot is the contract; without it there is nothing to hold."""
+    assert SNAPSHOT.is_file(), (
+        f"{SNAPSHOT.relative_to(REPO_ROOT)} is missing — it records the public "
+        f"import surface of `paperless_mcp`. Generate it with:\n"
+        f"    {UPDATE_COMMAND}\n"
+        "and commit the result."
+    )
+
+
+def test_snapshot_is_sorted_and_unique() -> None:
+    """A canonical (sorted, deduplicated) snapshot keeps its diffs reviewable."""
+    names = snapshot_names()
+    assert names == sorted(set(names)), (
+        f"{SNAPSHOT.relative_to(REPO_ROOT)} is not sorted/deduplicated — "
+        f"regenerate it with:\n    {UPDATE_COMMAND}"
+    )
+
+
+def test_public_import_surface_matches_snapshot() -> None:
+    """The imported surface and the snapshot must agree exactly, both ways.
+
+    Removals are the dangerous direction (an unmarked library break); additions
+    fail too, so the snapshot diff stays the reviewable record of every surface
+    change rather than silently lagging reality.
+    """
+    actual = set(current_surface())
+    expected = set(snapshot_names())
+    removed = sorted(expected - actual)
+    added = sorted(actual - expected)
+    problems: list[str] = []
+    if removed:
+        problems.append(
+            "public names REMOVED from the import surface of "
+            f"`paperless_mcp`: {', '.join(removed)}\n"
+            "  Removing or renaming a public name is a BREAKING change to the "
+            "public library interface.\n"
+            "  Either restore the names, or — if the removal is intentional —\n"
+            f"    1. regenerate the snapshot:  {UPDATE_COMMAND}\n"
+            "    2. mark the commit/PR breaking (`feat!:` / `fix!:`, or a "
+            "`BREAKING CHANGE:` footer)\n"
+            "       per the versioning policy's public-library-interface tier "
+            "(pvliesdonk/fastmcp-server-template#342)."
+        )
+    if added:
+        problems.append(
+            "public names ADDED to the import surface of "
+            f"`paperless_mcp`: {', '.join(added)}\n"
+            "  Additions are not breaking — record them so the snapshot stays "
+            "the reviewed surface:\n"
+            f"    {UPDATE_COMMAND}\n"
+            "  then commit the updated snapshot with this change."
+        )
+    assert not problems, "\n".join(problems)
+
+
+def _update_snapshot() -> int:
+    """Rewrite the snapshot from the currently importable surface.
+
+    Returns:
+        Number of names written.
+    """
+    names = current_surface()
+    SNAPSHOT.write_text(
+        _HEADER + "".join(f"{name}\n" for name in names), encoding="utf-8"
+    )
+    return len(names)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Public import-surface snapshot tool for `paperless_mcp`."
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="regenerate tests/public_import_surface.txt from the imported package",
+    )
+    if not parser.parse_args().update:
+        parser.error("nothing to do — pass --update to regenerate the snapshot")
+    count = _update_snapshot()
+    sys.stdout.write(
+        f"wrote {SNAPSHOT.relative_to(REPO_ROOT)} ({count} public names)\n"
+    )

--- a/tests/test_merge_back.py
+++ b/tests/test_merge_back.py
@@ -1,0 +1,157 @@
+"""Behavioral tests for scripts/merge_back.sh against sandbox git repos.
+
+After any release cut from a release/X.Y branch, the release workflow's
+merge-back job merges the branch back into main — mandatory, because PSR's
+already-released check is repo-global while its version computation is
+ancestry-scoped: an unmerged branch release leaves PSR on main recomputing the
+same version, finding the tag taken, and reporting "already released" forever.
+
+The script's contract, asserted here:
+
+* already-merged branches are a no-op (idempotent job re-runs);
+* a clean merge (the rc-finalise case: main untouched since the cut) lands the
+  branch's release commits, version metadata included;
+* conflicts on version-coupled files (the backport case: main released again
+  after the cut) resolve to MAIN's side — main is authoritative for current
+  metadata, the tag preserves the branch's state;
+* any other conflict aborts the merge, leaves a clean tree, and exits
+  non-zero for a human to take over.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MERGE_BACK = REPO_ROOT / "scripts" / "merge_back.sh"
+
+PYPROJECT_STUB = """\
+[project]
+name = "sandbox"
+version = "{version}"
+
+[tool.semantic_release]
+assets = ["server.json"]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
+"""
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return proc.stdout.strip()
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", message)
+
+
+def _write_version(repo: Path, version: str) -> None:
+    (repo / "pyproject.toml").write_text(PYPROJECT_STUB.format(version=version))
+    # json.dumps, not an f-string literal: doubled braces in this
+    # template-rendered file would read as Jinja delimiters.
+    (repo / "server.json").write_text(json.dumps({"version": version}) + "\n")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """A repo on main at version 4.0.0 with a release/4.0 branch cut from it."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    _write_version(repo, "4.0.0")
+    (repo / "CHANGELOG.md").write_text("# Changelog\n")
+    (repo / "app.py").write_text("x = 1\n")
+    _commit_all(repo, "chore: baseline")
+    _git(repo, "branch", "release/4.0")
+    return repo
+
+
+def _merge_back(repo: Path, branch: str, tag: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(MERGE_BACK), branch, tag],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_already_merged_branch_is_a_noop(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    before = _git(repo, "rev-parse", "HEAD")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.0")
+
+    assert result.returncode == 0, result.stderr
+    assert "nothing to do" in result.stdout
+    assert _git(repo, "rev-parse", "HEAD") == before
+
+
+def test_clean_merge_lands_release_commits(tmp_path: Path) -> None:
+    """The rc-finalise case: main untouched since the cut, so the branch's
+    version bump flows onto main via an ordinary clean merge."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    _write_version(repo, "4.1.0")
+    _commit_all(repo, "4.1.0")
+    _git(repo, "checkout", "main")
+
+    result = _merge_back(repo, "release/4.0", "v4.1.0")
+
+    assert result.returncode == 0, result.stderr
+    assert '"4.1.0"' in (repo / "server.json").read_text()
+    subject = _git(repo, "log", "-1", "--format=%s")
+    assert subject == "chore(release): merge release/4.0 back into main after v4.1.0"
+    # A real merge commit: two parents, so the tag becomes reachable from main.
+    assert len(_git(repo, "log", "-1", "--format=%P").split()) == 2
+
+
+def test_version_conflicts_resolve_to_mains_side(tmp_path: Path) -> None:
+    """The backport case: main has released a newer version since the cut, so
+    the version-coupled files conflict and main's side must win."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    _write_version(repo, "4.0.1")
+    _commit_all(repo, "4.0.1")
+    _git(repo, "checkout", "main")
+    _write_version(repo, "5.0.0")
+    _commit_all(repo, "5.0.0")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.1")
+
+    assert result.returncode == 0, result.stderr
+    assert 'version = "5.0.0"' in (repo / "pyproject.toml").read_text()
+    assert '"5.0.0"' in (repo / "server.json").read_text()
+    assert len(_git(repo, "log", "-1", "--format=%P").split()) == 2
+    # Ancestry restored: the branch tip is now reachable from main.
+    _git(repo, "merge-base", "--is-ancestor", "release/4.0", "HEAD")
+
+
+def test_code_conflicts_abort_cleanly(tmp_path: Path) -> None:
+    """A conflict outside the version-coupled set is real divergence: the
+    script must abort the merge, leave the tree clean, and exit non-zero."""
+    repo = _make_repo(tmp_path)
+    _git(repo, "checkout", "release/4.0")
+    (repo / "app.py").write_text("x = 2  # branch\n")
+    _commit_all(repo, "fix: branch-side change")
+    _git(repo, "checkout", "main")
+    (repo / "app.py").write_text("x = 3  # main\n")
+    _commit_all(repo, "fix: main-side change")
+    before = _git(repo, "rev-parse", "HEAD")
+
+    result = _merge_back(repo, "release/4.0", "v4.0.1")
+
+    assert result.returncode != 0
+    assert "need a human" in result.stderr
+    assert "app.py" in result.stderr
+    # Merge aborted: no MERGE_HEAD, clean tree, main tip unchanged.
+    assert not (repo / ".git" / "MERGE_HEAD").exists()
+    assert _git(repo, "status", "--porcelain") == ""
+    assert _git(repo, "rev-parse", "HEAD") == before

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -15,12 +15,39 @@ commits shipped a lockfile whose self entry lagged `pyproject.toml`, which made
 mutation (#325, #326).  The script is template-owned now, with
 `DOMAIN-MANIFESTS` seams for a project's own manifests; these tests are what
 keeps the two halves honest for anything added through those seams.
+
+A second invariant joined in template#345: the bumper must never pin a version
+the release will not publish.  Pre-releases skip PyPI, the MCP registry, and
+the marketplace publish, so on a pre-release run the manifests that name a
+published artifact (`server.json` and the Claude Code plugin pair) must stay
+at the last published stable, while `uv.lock` — which tracks `pyproject.toml`,
+not PyPI — must still move.  The behavioral tests below run the real script
+against a sandbox repo root and assert both directions: a stable version moves
+everything, a pre-release version moves only the lockfile.
+
+A third invariant joined in template#350: PSR's changelog writing has two
+halves that fail silently when either is missing.  `update` mode (the v10
+default) inserts version sections only at the insertion flag, so the config
+must name the flag and `CHANGELOG.md` must carry it — a flag-less changelog is
+never written, with no error.  And `changelog_file` must sit in its supported
+location (`changelog.default_templates`), not the deprecated bare
+`changelog.changelog_file` key.  The changelog tests below pin both halves.
+
+A fourth invariant joined in template#375: the two behavioral tests above
+prove the *bumper* never writes a pre-release pin, but nothing read the
+committed manifests themselves.  The stable-pin test below does, so a bad
+pin that arrives by hand edit or a half-applied update — outside the bumper
+— still fails.
 """
 
 from __future__ import annotations
 
 import json
+import os
+import re
+import shutil
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -30,10 +57,8 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUMPER = REPO_ROOT / "scripts" / "bump_manifests.py"
 PYPROJECT = REPO_ROOT / "pyproject.toml"
-PLUGIN_MANIFEST = REPO_ROOT / ".claude-plugin/plugin/.claude-plugin/plugin.json"
-PLUGIN_MCP_CONFIG = REPO_ROOT / ".claude-plugin/plugin/.mcp.json"
-MCPB_MANIFEST = REPO_ROOT / "packaging/mcpb/manifest.json.in"
-SERVER_MANIFEST = REPO_ROOT / "server.json"
+PLUGIN_JSON = Path(".claude-plugin/plugin/.claude-plugin/plugin.json")
+MCP_JSON = Path(".claude-plugin/plugin/.mcp.json")
 
 # Manifests the template itself bumps, mapped to the marker that proves the
 # bumper still handles them.  A domain manifest added through the
@@ -135,55 +160,220 @@ def test_domain_manifest_calls_sentinel_lives_inside_main() -> None:
     assert text.index("_bump_lockfile(version)") < start
 
 
-def test_claude_plugin_manifests_are_tracked_and_version_locked() -> None:
-    """Plugin manifests exist in a clean checkout and match the release version."""
-    paths = (PLUGIN_MANIFEST, PLUGIN_MCP_CONFIG)
-    tracked = subprocess.run(
-        [
-            "git",
-            "ls-files",
-            "--error-unmatch",
-            *(str(path.relative_to(REPO_ROOT)) for path in paths),
-        ],
-        cwd=REPO_ROOT,
-        check=False,
+def test_changelog_config_lives_in_the_supported_location() -> None:
+    """`changelog_file` sits under `default_templates`; `mode` is pinned.
+
+    The bare `changelog.changelog_file` key is the pre-v9.11 deprecated
+    location (template#350) — PSR may stop honouring it in a future major,
+    and while it is honoured it silently rewires `output_format`.  `mode` is
+    asserted so the update-at-flag contract the seeded CHANGELOG.md relies on
+    stays explicit rather than riding on PSR's default.
+    """
+    changelog_cfg = _semantic_release_config()["changelog"]
+    assert "changelog_file" not in changelog_cfg, (
+        "changelog.changelog_file is the deprecated pre-v9.11 location — move "
+        "it to [tool.semantic_release.changelog.default_templates]"
+    )
+    assert changelog_cfg["default_templates"]["changelog_file"] == "CHANGELOG.md"
+    assert changelog_cfg["mode"] == "update"
+
+
+def test_changelog_carries_the_insertion_flag() -> None:
+    """`CHANGELOG.md` contains the exact insertion flag the config names.
+
+    In `update` mode PSR inserts each release's version section at this flag
+    and preserves the rest of the file; without the flag it writes nothing —
+    silently, on every release (template#350).  If this project's
+    CHANGELOG.md predates the flag, add the line once by hand, anywhere a
+    machine-written version list should begin (typically after the intro
+    prose).
+    """
+    flag = _semantic_release_config()["changelog"]["insertion_flag"]
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert flag in changelog, (
+        f"CHANGELOG.md lacks the PSR insertion flag — add this exact line "
+        f"once, where version sections should be inserted: {flag}"
+    )
+
+
+_PRERELEASE_SUFFIX = re.compile(r"-(?:alpha|beta|rc|dev|pre|a|b)\b", re.IGNORECASE)
+
+
+def _published_manifest_versions() -> dict[str, str]:
+    """Version each committed published-manifest currently pins.
+
+    These are the files the "Manifest version lockstep" rule keeps at the
+    latest *stable* release: ``server.json``'s own version and its pypi
+    package versions, plus the Claude plugin pair. The oci image identifier is
+    excluded — it legitimately ends in the tag form ``:vX.Y.Z``.
+    """
+    versions: dict[str, str] = {}
+    server = json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))
+    versions["server.json version"] = str(server["version"])
+    for pkg in server.get("packages", []):
+        if pkg.get("registryType") == "pypi":
+            versions[f"server.json pypi {pkg.get('identifier', '')}"] = str(
+                pkg["version"]
+            )
+    plugin = json.loads((REPO_ROOT / PLUGIN_JSON).read_text(encoding="utf-8"))
+    versions["plugin.json version"] = str(plugin["version"])
+    mcp = json.loads((REPO_ROOT / MCP_JSON).read_text(encoding="utf-8"))
+    for server_cfg in mcp.values():
+        for arg in server_cfg.get("args", []):
+            if isinstance(arg, str) and "==" in arg:
+                versions[f".mcp.json pin {arg}"] = arg.split("==", 1)[1]
+    return versions
+
+
+def test_committed_manifest_pins_are_stable_versions() -> None:
+    """No committed published-manifest pins a pre-release version.
+
+    The bumper leaves these files at the last published stable on a
+    pre-release run (proven by the sandbox tests below), but a value can
+    reach the committed file another way — a hand edit, a bad merge, a
+    half-applied copier update.  A pre-release pin such as ``X.Y.Z-rc.N``
+    names a version PyPI, the MCP registry, and the marketplace never
+    publish, so ``uvx --from pkg==X.Y.Z-rc.N`` cannot resolve it (the failure
+    tracked at markdown-vault-mcp#1053).  This reads the committed files
+    themselves, which the sandbox tests never touch.
+    """
+    bad = {
+        where: ver
+        for where, ver in _published_manifest_versions().items()
+        if _PRERELEASE_SUFFIX.search(ver)
+    }
+    assert not bad, (
+        "committed manifests must pin the latest stable release, but these "
+        "carry a pre-release version: "
+        + ", ".join(f"{where} = {ver}" for where, ver in sorted(bad.items()))
+    )
+
+
+def _stable_release_tags() -> list[str] | None:
+    """Stable ``vX.Y.Z`` tags in this repo, or ``None`` when git is absent.
+
+    A freshly generated project is not yet a git repository and has no tags,
+    so the caller skips there rather than failing.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "tag", "--list"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return [t for t in completed.stdout.split() if re.fullmatch(r"v\d+\.\d+\.\d+", t)]
+
+
+def test_committed_server_version_matches_a_released_tag() -> None:
+    """When the repo has stable tags, ``server.json`` names one of them.
+
+    Best-effort and self-skipping: it asserts nothing before a project's
+    first stable, but once stables exist a committed version with no matching
+    ``vX.Y.Z`` tag means the pin drifted from what was actually released.
+    """
+    tags = _stable_release_tags()
+    if not tags:
+        pytest.skip("no stable release tags in this repository yet")
+    version = str(
+        json.loads((REPO_ROOT / "server.json").read_text(encoding="utf-8"))["version"]
+    )
+    if version in {"0.0.0", "0.1.0"}:
+        pytest.skip("initial placeholder version, before the first release")
+    assert f"v{version}" in tags, (
+        f"server.json pins {version}, but no matching stable tag v{version} "
+        "exists — the manifest must name a released stable version"
+    )
+
+
+def _run_bumper(workdir: Path, version: str) -> subprocess.CompletedProcess[str]:
+    """Run the real bumper against ``workdir`` with ``NEW_VERSION`` set."""
+    return subprocess.run(
+        [sys.executable, str(BUMPER)],
+        cwd=workdir,
+        env={**os.environ, "NEW_VERSION": version},
         capture_output=True,
         text=True,
-    )
-    assert tracked.returncode == 0, tracked.stderr
-
-    version = json.loads(SERVER_MANIFEST.read_text(encoding="utf-8"))["version"]
-    plugin = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
-    mcp = json.loads(PLUGIN_MCP_CONFIG.read_text(encoding="utf-8"))
-    assert plugin["version"] == version
-    assert any(
-        argument.endswith(f"=={version}")
-        for server in mcp.values()
-        for argument in server["args"]
+        check=False,
     )
 
 
-def test_generated_install_manifests_expose_paperless_configuration() -> None:
-    """MCPB and Claude plugin screens map the same required Paperless settings."""
-    mcpb = json.loads(MCPB_MANIFEST.read_text(encoding="utf-8"))
-    plugin = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
-    plugin_mcp = json.loads(PLUGIN_MCP_CONFIG.read_text(encoding="utf-8"))
+@pytest.fixture
+def release_sandbox(tmp_path: Path) -> Path:
+    """A minimal repo root the bumper can rewrite without touching this repo.
 
-    for manifest in (mcpb, plugin):
-        user_config = manifest.get("user_config", manifest.get("userConfig"))
-        assert user_config["paperless_url"]["required"] is True
-        assert user_config["api_token"]["required"] is True
-        assert user_config["api_token"]["sensitive"] is True
+    `server.json` and the plugin manifests are copied verbatim so the test exercises the
+    real manifest shapes; `pyproject.toml` and `uv.lock` are minimal stand-ins
+    carrying only what `_bump_lockfile` reads.
+    """
+    shutil.copy(REPO_ROOT / "server.json", tmp_path / "server.json")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "sandbox-pkg"\nversion = "1.2.3"\n', encoding="utf-8"
+    )
+    (tmp_path / "uv.lock").write_text(
+        '[[package]]\nname = "sandbox-pkg"\nversion = "1.2.3"\n', encoding="utf-8"
+    )
+    for manifest in (PLUGIN_JSON, MCP_JSON):
+        (tmp_path / manifest).parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(REPO_ROOT / manifest, tmp_path / manifest)
+    return tmp_path
 
-    api_token_reference = "${user_config." + "api_token}"
-    assert (
-        mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_PAPERLESS_URL"]
-        == "${user_config.paperless_url}"
-    )
-    assert (
-        mcpb["server"]["mcp_config"]["env"]["PAPERLESS_MCP_API_TOKEN"]
-        == api_token_reference
-    )
-    env = plugin_mcp["paperless-mcp"]["env"]
-    assert env["PAPERLESS_MCP_PAPERLESS_URL"] == "${user_config.paperless_url}"
-    assert env["PAPERLESS_MCP_API_TOKEN"] == api_token_reference
+
+def test_stable_release_bumps_every_published_version_field(
+    release_sandbox: Path,
+) -> None:
+    """A stable version moves every manifest the release publishes."""
+    result = _run_bumper(release_sandbox, "9.9.9")
+    assert result.returncode == 0, result.stderr
+
+    server = json.loads((release_sandbox / "server.json").read_text(encoding="utf-8"))
+    assert server["version"] == "9.9.9"
+    pypi = [p for p in server["packages"] if p.get("registryType") == "pypi"]
+    assert pypi and all(p["version"] == "9.9.9" for p in pypi)
+    oci = [p for p in server["packages"] if p.get("registryType") == "oci"]
+    assert all(p["identifier"].endswith(":v9.9.9") for p in oci)
+
+    lock = (release_sandbox / "uv.lock").read_text(encoding="utf-8")
+    assert 'version = "9.9.9"' in lock
+
+    plugin = json.loads((release_sandbox / PLUGIN_JSON).read_text(encoding="utf-8"))
+    assert plugin["version"] == "9.9.9"
+    mcp = json.loads((release_sandbox / MCP_JSON).read_text(encoding="utf-8"))
+    pins = [
+        arg
+        for server_cfg in mcp.values()
+        for arg in server_cfg.get("args", [])
+        if "==" in arg
+    ]
+    assert pins and all(pin.endswith("==9.9.9") for pin in pins)
+
+
+@pytest.mark.parametrize("version", ["9.9.9-rc.1", "9.9.9-rc.12"])
+def test_prerelease_leaves_published_version_fields_untouched(
+    release_sandbox: Path, version: str
+) -> None:
+    """A pre-release run must not pin versions PyPI/the registry never get.
+
+    `publish-pypi`, `publish-registry`, and the marketplace publish are all
+    gated on PSR's `is_prerelease` output, so a pre-release version never
+    exists on those channels — pinning it would leave the branch naming an
+    uninstallable version between stables (template#345).  `uv.lock` still
+    moves: it tracks `pyproject.toml`, and lagging there breaks
+    `uv lock --check` on `main`.
+    """
+    before_server = (release_sandbox / "server.json").read_bytes()
+    before_plugin = (release_sandbox / PLUGIN_JSON).read_bytes()
+    before_mcp = (release_sandbox / MCP_JSON).read_bytes()
+
+    result = _run_bumper(release_sandbox, version)
+    assert result.returncode == 0, result.stderr
+    assert "pre-release" in result.stdout
+
+    assert (release_sandbox / "server.json").read_bytes() == before_server
+    assert (release_sandbox / PLUGIN_JSON).read_bytes() == before_plugin
+    assert (release_sandbox / MCP_JSON).read_bytes() == before_mcp
+    lock = (release_sandbox / "uv.lock").read_text(encoding="utf-8")
+    assert f'version = "{version}"' in lock

--- a/tests/test_structural_gate.py
+++ b/tests/test_structural_gate.py
@@ -8,6 +8,7 @@ wired correctly. Only rendered when ``enable_structural_gate`` is true.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -200,21 +201,21 @@ def test_precommit_config_wires_pre_push_hook() -> None:
     block = _structural_hook_block(text)
     assert "stages: [pre-push]" in block
     assert "language: system" in block
-    # Mirrors the CI HAS_PY skip: no Python in the push → hook does not run.
+    # Mirrors the script's no-Python skip: no Python in the push → hook does
+    # not run.
     assert "types: [python]" in block
-    # The `entry: bash -c` wrapper is load-bearing: it makes the shell (not
-    # pre-commit's arg splitter) own the --options quoting verified by the
-    # end-to-end test. Assert it so a refactor to a direct `uv run` entry —
-    # which would break that quoting — can't pass silently.
-    assert "entry: bash -c " in block
-    assert f"--extend-select={STRUCTURAL}" in block
+    # The hook delegates to the shared script (one implementation for hook and
+    # CI); the diff-quality command itself is asserted on the script below.
+    assert "entry: bash scripts/structural_gate.sh" in block
 
 
 def test_ci_has_structure_job() -> None:
     text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     assert "structure:" in text
-    assert "diff-quality" in text
-    assert f"--extend-select={STRUCTURAL}" in text
+    # CI runs the same shared script as the pre-push hook, pinning the compare
+    # branch to the PR's real base via the script's env override.
+    assert "scripts/structural_gate.sh" in text
+    assert "STRUCTURAL_GATE_BASE" in text
     # PR-only, like the diff-cover patch-coverage steps.
     assert "github.event_name == 'pull_request'" in text
 
@@ -231,12 +232,85 @@ def test_claudemd_documents_the_gate_command() -> None:
 
 
 def test_structural_select_string_is_identical_across_surfaces() -> None:
-    """The select string lives in three rendered files; drift between them is a
-    silent gate weakening. Assert all three carry the canonical string verbatim.
+    """The select string lives in the shared script (which the pre-commit hook
+    and the CI job both execute) and in CLAUDE.md's documented command; drift
+    between them is a silent gate weakening. Assert both carry the canonical
+    string verbatim.
     """
     needle = f"--extend-select={STRUCTURAL}"
-    precommit = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
-    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    script = (REPO_ROOT / "scripts" / "structural_gate.sh").read_text()
     claudemd = (REPO_ROOT / "CLAUDE.md").read_text()
-    for name, text in [("pre-commit", precommit), ("ci", ci), ("CLAUDE.md", claudemd)]:
+    for name, text in [("structural_gate.sh", script), ("CLAUDE.md", claudemd)]:
         assert needle in text, f"{name} missing canonical structural select"
+
+
+def _print_base(repo: Path, env: dict[str, str] | None = None) -> str:
+    """Run the script's base-derivation seam and return the resolved base."""
+    proc = subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "structural_gate.sh")],
+        cwd=repo,
+        env={**os.environ, "STRUCTURAL_GATE_PRINT_BASE": "1", **(env or {})},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _commit(repo: Path, name: str, stamp: str) -> None:
+    (repo / name).write_text(name + "\n")
+    _git(["add", "."], repo)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", name],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_DATE": stamp,
+            "GIT_COMMITTER_DATE": stamp,
+        },
+    )
+
+
+def test_gate_script_derives_compare_branch(tmp_path: Path) -> None:
+    """Base derivation: a branch off main compares against origin/main; a
+    backport branch off release/X.Y compares against origin/release/X.Y (the
+    branch its PR targets); an explicit STRUCTURAL_GATE_BASE always wins.
+
+    The remote-tracking refs are created directly with update-ref — the
+    derivation reads refs/remotes/origin/*, not a live remote.
+    """
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(["init", "-b", "main"], repo)
+    _commit(repo, "c1.py", "2026-01-01T10:00:00")
+    _commit(repo, "c2.py", "2026-01-02T10:00:00")
+    _git(["update-ref", "refs/remotes/origin/main", "HEAD"], repo)
+
+    # Feature branch off main: only origin/main exists -> origin/main.
+    _git(["checkout", "-b", "feature"], repo)
+    _commit(repo, "f1.py", "2026-01-05T10:00:00")
+    assert _print_base(repo) == "origin/main"
+
+    # Cut release/4.0 from main's tip, advance it (newer merge-base than
+    # main's for anything branched off it), publish as a remote ref.
+    _git(["checkout", "-b", "release/4.0", "main"], repo)
+    _commit(repo, "r1.py", "2026-01-03T10:00:00")
+    _git(["update-ref", "refs/remotes/origin/release/4.0", "HEAD"], repo)
+
+    # Backport branch off the release branch -> origin/release/4.0.
+    _git(["checkout", "-b", "backport", "release/4.0"], repo)
+    _commit(repo, "b1.py", "2026-01-04T10:00:00")
+    assert _print_base(repo) == "origin/release/4.0"
+
+    # The feature branch still resolves to origin/main: both merge-bases land
+    # on the same cut commit, and the tie deliberately prefers origin/main...
+    _git(["checkout", "feature"], repo)
+    assert _print_base(repo) == "origin/main"
+    # ...and the explicit override beats any derivation.
+    assert (
+        _print_base(repo, {"STRUCTURAL_GATE_BASE": "origin/somewhere"})
+        == "origin/somewhere"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -569,61 +572,58 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3e/e54cde8c01631a5a8226ccd617eab9e57fd5cfdad90f1a9e6bb570794631/cryptography-50.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5e34edd123674534acd70147f0ca331eaa2c74e6325fb2028c886aa26ba0b68c", size = 3963170, upload-time = "2026-07-31T14:24:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b6/0b9e125e90f3d2dcf599a218a899cda7326a3158cfa258723f0b398b08f6/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5e1172eb569ea8a872796576e6a67c276351728b6455d5beb01242b027c6a", size = 4692441, upload-time = "2026-07-31T14:24:53.743Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c9/a5151588710785a96d7bc4de27d4cd62f263bbbcb203cfe29df537eb6505/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:910d11e1a385c654bf738bf3e6b8e6ed5de0f5610fcae2be9e5b398d8081d20e", size = 4699810, upload-time = "2026-07-31T14:24:55.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1a/15b92b25eb6ce3089cd49377ae990a0f3ad485a510f968aed1f19dbdcdf2/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:62598a8a57f815db4c6259a4e97d857dab56697e7de8e8ab02352ab74da1995d", size = 4691924, upload-time = "2026-07-31T14:24:58.082Z" },
+    { url = "https://files.pythonhosted.org/packages/62/15/219075012ab13e8905f3cd572204f4acb4b111df787104346b9bc0cea789/cryptography-50.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:07479a1cb08219ab719147e742e76090c9c773321959bb94946fffdd397a6437", size = 4699593, upload-time = "2026-07-31T14:24:59.951Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/c2c5fce26f0ee40d21bafe7f191d29a34b35a65ac4fe8a1191d1983612e9/cryptography-50.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c99c003e088647b8a5b7c145d6f78c335f6348332b62e142d411c4b63d1460b9", size = 3813796, upload-time = "2026-07-31T14:25:02.298Z" },
 ]
 
 [[package]]
@@ -1020,11 +1020,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -1107,14 +1107,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.4"
+version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1398,9 +1398,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
 ]
 
 [[package]]
@@ -2157,16 +2157,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -2216,11 +2216,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2375,11 +2375,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #84

## Summary
- Upgrade the Copier baseline from v3.6.0 to v4.1.0.
- Adopt v4 release/ruleset infrastructure, release notes, import snapshot, and manifest lockstep checks.
- Reconcile all v4.1 skip-listed migration requirements without tracking execution artifacts.

## Verification
- `uv run pytest -x -q` (311 passed, 1 skipped)
- coverage: 88.92%
- `python scripts/gen_config_surface.py --check`
- `uv lock --check`
- `uv run ruff check --fix .`
- `uv run ruff format --check .`
- `uv run mypy src/ tests/`
- `uv run mkdocs build --strict`
- `uv run pre-commit run --all-files`