### PR TITLE
docs: explain bounded MCPB build backend

### DIFF
--- a/packaging/mcpb/pyproject.toml.in
+++ b/packaging/mcpb/pyproject.toml.in
@@ -1,5 +1,14 @@
 # Rendered at build time by envsubst. ${VERSION} matches the package release.
 [build-system]
+# Bounded to match the project's own pyproject.toml. This backend runs only
+# on the fallback launch path -- `server.type: "uv"` with `entry_point`, where
+# the host does `uv run src/server.py` and uv builds this project on the
+# user's machine. The primary path (`mcp_config.command: "uvx"`) fetches the
+# published wheel and never touches it.
+#
+# Nothing publishes or `twine check`s this project, so the failure in #479
+# cannot happen here. The bound is for reproducibility: an unpinned backend
+# on an end user's machine resolves to whatever is newest that day.
 requires = ["hatchling>=1.32,<1.33"]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
## Summary
- Adopt the full upstream rationale for the skipped MCPB Hatchling constraint.

## Verification
- Pre-commit checks for the changed file passed.

Closes #88