### PR TITLE
chore: prepare release 1.0.2-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 <!-- version list -->
 
+## 1.0.2-rc.0 (2026-08-25)
+
+### Bug Fixes
+
+- rebuild create_download_link on pvl-core's Transfer API (#75)
+
 ## 0.1.0 - 2026-04-23
 
 ### Added

--- a/docs/releases/1.0.md
+++ b/docs/releases/1.0.md
@@ -1,0 +1,88 @@
+# 1.0
+
+<!-- notes-range-end: 0593b0ba7b78dd2410e60df31bedad01f0859517 -->
+
+<!-- RELEASE-SUMMARY v1.0.2 START -->
+v1.0.2 modernizes the server on the latest shared `fastmcp-pvl-core` runtime
+and adds two new ways to get the server configured and installed: a
+browser-based guided configuration wizard and a Claude Code plugin
+distribution channel. It also removes `create_download_link`, a tool that
+had silently never worked on any transport.
+<!-- RELEASE-SUMMARY v1.0.2 END -->
+
+## Two new ways to get set up
+
+Paperless MCP carried its shared server runtime forward from
+`fastmcp-pvl-core` 1.0.0 to 4.11.3, adopting the underlying project
+template from v1.2.0 to v5.6.3 across four staged upgrades
+([#77](https://github.com/pvliesdonk/paperless-mcp/pull/77),
+[#83](https://github.com/pvliesdonk/paperless-mcp/pull/83),
+[#85](https://github.com/pvliesdonk/paperless-mcp/pull/85),
+[#87](https://github.com/pvliesdonk/paperless-mcp/pull/87)). Two of the
+new capabilities that upgrade unlocked are directly useful for anyone
+setting the server up for the first time.
+
+**The [configuration generator](https://pvliesdonk.github.io/paperless-mcp/latest/configuration-generator/)**
+is a browser page that asks a few questions about your deployment and
+produces a ready-to-use configuration. Everything runs client-side, and
+nothing typed into it is sent anywhere. Secret fields such as your
+Paperless API token are excluded from any shareable link
+([#76](https://github.com/pvliesdonk/paperless-mcp/issues/76)).
+
+**A Claude Code plugin channel** lets Claude Code install and run the
+server directly. Every stable release publishes a marketplace entry that
+installs the released PyPI package via `uvx`, and every release (plus
+every merge to `main`) also attaches a standalone
+`paperless-mcp-plugin-<version>.zip` that can be loaded for a single
+session with `claude --plugin-url <url>`, a way to try a release
+candidate without installing anything
+([#82](https://github.com/pvliesdonk/paperless-mcp/issues/82); see
+[Testing a candidate's Claude Code plugin](../deployment/release-process.md#testing-a-candidates-claude-code-plugin)).
+The plugin's install screen collects your Paperless URL and API token,
+plus optional HTTP timeout, retry count, default page size, and public
+URL overrides.
+
+Both additions are new distribution/setup surfaces; as of this release
+[the installation guide](../installation.md) still documents only the
+PyPI, Docker, and from-source paths.
+
+## Operator tool visibility controls
+
+The same runtime upgrade adds `PAPERLESS_MCP_TOOLS_ALLOW` and
+`PAPERLESS_MCP_TOOLS_DENY`, letting an operator expose only a chosen set
+of tools or hide specific ones from a given instance, useful for running
+a read-heavy or narrowly scoped deployment without a custom build. See
+[Configuration](../configuration.md#tool-visibility) for both
+variables.
+
+## Retiring `create_download_link`
+
+`create_download_link` is gone from this release. It was never actually
+reachable: `ToolContext` was built before the artifact store it depended
+on existed, so `ctx.artifact_store` was always `None` and the tool's own
+registration step returned early on every transport
+([#74](https://github.com/pvliesdonk/paperless-mcp/issues/74)). Its
+underlying dependency, `fastmcp-pvl-core`'s `ArtifactStore`, has itself
+been replaced upstream by a Transfer API
+(`register_transfer_routes`/`TransferSink`); a rebuild on the new API
+landed and was reverted in the same release
+([#75](https://github.com/pvliesdonk/paperless-mcp/pull/75),
+[#79](https://github.com/pvliesdonk/paperless-mcp/pull/79)) because it
+arrived out of sequence with the staged template upgrade, not because the
+approach was wrong. A supported replacement remains tracked in
+[#43](https://github.com/pvliesdonk/paperless-mcp/issues/43).
+
+Because the tool never worked in any released version, no working
+capability is lost by its removal.
+
+## Upgrading
+
+No operator action is required. `create_download_link`'s removal is not
+classified as breaking: the tool never functioned in any prior release,
+so there is no reachable behavior for an upgrade to take away. The
+`fastmcp-pvl-core` upgrade broadens the general server configuration
+surface inherited from the shared runtime. See `.env.example` and
+[Configuration](../configuration.md) for the current reference.
+
+<!-- PATCH-RELEASES-START -->
+<!-- PATCH-RELEASES-END -->

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -8,6 +8,5 @@ GitHub release links back to its page here.
 
 <!-- RELEASE-PAGES-START: newest series first; one list entry per page.
      The first real entry replaces the placeholder line below. -->
-No release pages yet. The first entry appears with the first stable
-release cut after this project adopted release-notes pages.
+- [1.0](1.0.md)
 <!-- RELEASE-PAGES-END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.1"
+version = "1.0.2-rc.0"
 description = "Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields."
 readme = "README.md"
 license = "LicenseRef-Proprietary"  # starter: TODO update when you pick a license (see LICENSE)

--- a/uv.lock
+++ b/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.1"
+version = "1.0.2rc0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **1.0.2-rc.0** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Bug Fixes

- rebuild create_download_link on pvl-core's Transfer API (#75)
