### PR TITLE
chore: prepare release 1.0.2

### DIFF
--- a/.claude-plugin/plugin/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "paperless-mcp",
   "description": "Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "pvliesdonk"
   },

--- a/.claude-plugin/plugin/.mcp.json
+++ b/.claude-plugin/plugin/.mcp.json
@@ -3,7 +3,7 @@
     "command": "uvx",
     "args": [
       "--from",
-      "pvliesdonk-paperless-mcp[all]==1.0.1",
+      "pvliesdonk-paperless-mcp[all]==1.0.2",
       "paperless-mcp",
       "serve"
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 <!-- version list -->
 
+## 1.0.2 (2026-08-25)
+
+### Bug Fixes
+
+- rebuild create_download_link on pvl-core's Transfer API (#75)
+
 ## 1.0.2-rc.0 (2026-08-25)
 
 ### Bug Fixes

--- a/docs/releases/1.0.md
+++ b/docs/releases/1.0.md
@@ -1,6 +1,6 @@
 # 1.0
 
-<!-- notes-range-end: 0593b0ba7b78dd2410e60df31bedad01f0859517 -->
+<!-- notes-range-end: dd31d96becf3319313d5e3a9cfdf89da18d7d4d3 -->
 
 <!-- RELEASE-SUMMARY v1.0.2 START -->
 v1.0.2 modernizes the server on the latest shared `fastmcp-pvl-core` runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.2-rc.0"
+version = "1.0.2"
 description = "Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields."
 readme = "README.md"
 license = "LicenseRef-Proprietary"  # starter: TODO update when you pick a license (see LICENSE)

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pvliesdonk/paperless-mcp",
   "title": "Paperless MCP",
   "description": "Paperless-NGX document management over MCP: search, tag, upload, and read documents; manage tags, correspondents, document types, and custom fields.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "websiteUrl": "https://pvliesdonk.github.io/paperless-mcp/",
   "repository": {
     "url": "https://github.com/pvliesdonk/paperless-mcp",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "pvliesdonk-paperless-mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -93,7 +93,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/pvliesdonk/paperless-mcp:v1.0.1",
+      "identifier": "ghcr.io/pvliesdonk/paperless-mcp:v1.0.2",
       "transport": {
         "type": "streamable-http",
         "url": "http://localhost:{--port}/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "pvliesdonk-paperless-mcp"
-version = "1.0.2rc0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp-pvl-core" },


### PR DESCRIPTION
Merging this pull request releases **1.0.2** — the merge is the release
decision.  On merge, the Release workflow tags the merge commit, creates
the GitHub release, and runs the publish fan-out; for a stable promotion the same-source guard
(`scripts/promotion_guard.sh`) runs first, so drifted source refuses with no
tag created.

This PR also carries the release-notes page under `docs/releases/`,
drafted by the prepare run's notes job — review it as part of the release
(an evidence check: every causal claim must trace to its linked issue or
PR).  The PR is held as a DRAFT until the notes land; the notes job marks
it ready.  Still draft means the notes job is running or failed — check
the prepare run.

Do NOT use GitHub's "Update branch" button on this PR — the only valid
refresh is re-dispatching the Release Prepare workflow, which recreates this
branch from its base.

## Changelog

## Bug Fixes

- rebuild create_download_link on pvl-core's Transfer API (#75)
